### PR TITLE
Wait in tests

### DIFF
--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -9,6 +9,7 @@ from qtpy.QtCore import Qt, QThread
 from qtpy.QtWidgets import QPushButton
 
 from napari._qt.dialogs.qt_notification import NapariQtNotification
+from napari._tests.utils import DEFAULT_TIMEOUT_SECS
 from napari.utils.notifications import (
     ErrorNotification,
     Notification,
@@ -20,7 +21,7 @@ from napari.utils.notifications import (
 def _threading_warn():
     thr = threading.Thread(target=_warn)
     thr.start()
-    thr.join()
+    thr.join(timeout=DEFAULT_TIMEOUT_SECS)
 
 
 def _warn():
@@ -30,7 +31,7 @@ def _warn():
 def _threading_raise():
     thr = threading.Thread(target=_raise)
     thr.start()
-    thr.join()
+    thr.join(timeout=DEFAULT_TIMEOUT_SECS)
 
 
 def _raise():
@@ -104,7 +105,7 @@ def test_show_notification_from_thread(mock_show, monkeypatch, qtbot):
             )
             res = NapariQtNotification.show_notification(notif)
             assert isinstance(res, Future)
-            assert res.result() is None
+            assert res.result(timeout=DEFAULT_TIMEOUT_SECS) is None
             mock_show.assert_called_once()
 
     thread = CustomThread()

--- a/napari/_qt/_tests/test_qt_notifications.py
+++ b/napari/_qt/_tests/test_qt_notifications.py
@@ -1,5 +1,4 @@
 import threading
-import time
 import warnings
 from concurrent.futures import Future
 from unittest.mock import patch
@@ -21,20 +20,20 @@ from napari.utils.notifications import (
 def _threading_warn():
     thr = threading.Thread(target=_warn)
     thr.start()
+    thr.join()
 
 
 def _warn():
-    time.sleep(0.1)
     warnings.warn('warning!')
 
 
 def _threading_raise():
     thr = threading.Thread(target=_raise)
     thr.start()
+    thr.join()
 
 
 def _raise():
-    time.sleep(0.1)
     raise ValueError("error!")
 
 
@@ -79,7 +78,6 @@ def test_notification_manager_via_gui(
         ]:
             notification_manager.records = []
             qtbot.mouseClick(btt, Qt.LeftButton)
-            qtbot.wait(500)
             assert len(notification_manager.records) == 1
             assert notification_manager.records[0].message == expected_message
             notification_manager.records = []

--- a/napari/_qt/_tests/test_qt_utils.py
+++ b/napari/_qt/_tests/test_qt_utils.py
@@ -4,7 +4,6 @@ from qtpy.QtWidgets import QMainWindow
 
 from napari._qt.utils import (
     QBYTE_FLAG,
-    add_flash_animation,
     is_qbyte,
     qbytearray_to_str,
     qt_might_be_rich_text,
@@ -36,7 +35,6 @@ def test_signal_blocker(qtbot):
     obj.test_signal.connect(err)
     with qt_signals_blocked(obj):
         obj.go()
-        qtbot.wait(750)
 
 
 def test_is_qbyte_valid():
@@ -84,18 +82,6 @@ def test_qbytearray_to_str_and_back(qtbot):
 
     qbyte = widget.saveState()
     assert str_to_qbytearray(qbytearray_to_str(qbyte)) == qbyte
-
-
-def test_add_flash_animation(qtbot):
-    widget = QMainWindow()
-    qtbot.addWidget(widget)
-    assert widget.graphicsEffect() is None
-    add_flash_animation(widget)
-    assert widget.graphicsEffect() is not None
-    assert hasattr(widget, "_flash_animation")
-    qtbot.wait(350)
-    assert widget.graphicsEffect() is None
-    assert not hasattr(widget, "_flash_animation")
 
 
 def test_qt_might_be_rich_text(qtbot):

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -336,27 +336,10 @@ def test_qt_viewer_clipboard_with_flash(make_napari_viewer, qtbot):
     clipboard_image = QGuiApplication.clipboard().image()
     assert clipboard_image.isNull()
 
-    # capture screenshot
-    with pytest.warns(FutureWarning):
-        viewer.window.qt_viewer.clipboard(flash=True)
-
+    # capture screenshot of canvas only
     viewer.window.clipboard(flash=False, canvas_only=True)
-
     clipboard_image = QGuiApplication.clipboard().image()
     assert not clipboard_image.isNull()
-
-    # ensure the flash effect is applied
-    assert (
-        viewer.window._qt_viewer._canvas_overlay.graphicsEffect() is not None
-    )
-    assert hasattr(
-        viewer.window._qt_viewer._canvas_overlay, "_flash_animation"
-    )
-    qtbot.wait(500)  # wait for the animation to finish
-    assert viewer.window._qt_viewer._canvas_overlay.graphicsEffect() is None
-    assert not hasattr(
-        viewer.window._qt_viewer._canvas_overlay, "_flash_animation"
-    )
 
     # clear clipboard and grab image from application view
     QGuiApplication.clipboard().clear()
@@ -367,13 +350,6 @@ def test_qt_viewer_clipboard_with_flash(make_napari_viewer, qtbot):
     viewer.window.clipboard(flash=True)
     clipboard_image = QGuiApplication.clipboard().image()
     assert not clipboard_image.isNull()
-
-    # ensure the flash effect is applied
-    assert viewer.window._qt_window.graphicsEffect() is not None
-    assert hasattr(viewer.window._qt_window, "_flash_animation")
-    qtbot.wait(500)  # wait for the animation to finish
-    assert viewer.window._qt_window.graphicsEffect() is None
-    assert not hasattr(viewer.window._qt_window, "_flash_animation")
 
 
 def test_qt_viewer_clipboard_without_flash(make_napari_viewer):
@@ -486,6 +462,7 @@ def test_memory_leaking(qtbot, make_napari_viewer):
     labels = weakref.ref(viewer.add_labels(data))
     del viewer.layers[0]
     del viewer.layers[0]
+    # TODO: what are we waiting for? Can we use qtbot.waitUntil?
     qtbot.wait(100)
     gc.collect()
     gc.collect()
@@ -501,6 +478,7 @@ def test_leaks_image(qtbot, make_napari_viewer):
     dr = weakref.ref(lr().data)
 
     viewer.layers.clear()
+    # TODO: what are we waiting for? Can we use qtbot.waitUntil?
     qtbot.wait(100)
     gc.collect()
     assert not gc.collect()
@@ -516,6 +494,7 @@ def test_leaks_labels(qtbot, make_napari_viewer):
     )
     dr = weakref.ref(lr().data)
     viewer.layers.clear()
+    # TODO: what are we waiting for? Can we use qtbot.waitUntil?
     qtbot.wait(100)
     gc.collect()
     assert not gc.collect()

--- a/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_qt_plugin_dialog.py
@@ -52,6 +52,7 @@ def plugin_dialog(qtbot, monkeypatch):
 
     widget = qt_plugin_dialog.QtPluginDialog()
     widget.show()
+    # TODO: what are we waiting for? Can we use qtbot.waitSignal or waitUntil?
     qtbot.wait(300)
     qtbot.add_widget(widget)
     return widget
@@ -78,6 +79,7 @@ def plugin_dialog_constructor(qtbot, monkeypatch):
     )
     widget = qt_plugin_dialog.QtPluginDialog()
     widget.show()
+    # TODO: what are we waiting for? Can we use qtbot.waitSignal or waitUntil?
     qtbot.wait(300)
     qtbot.add_widget(widget)
     return widget

--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -12,6 +12,7 @@ from napari._qt.layer_controls.qt_image_controls_base import (
     QtBaseImageControls,
     range_to_decimals,
 )
+from napari._tests.utils import DEFAULT_TIMEOUT_MILLIS
 from napari.layers import Image, Surface
 
 _IMAGE = np.arange(100).astype(np.uint16).reshape((10, 10))
@@ -74,7 +75,9 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     reset_button = qtctrl.clim_popup.findChild(
         QPushButton, "reset_clims_button"
     )
-    with qtbot.waitSignal(reset_button.clicked):
+    with qtbot.waitSignal(
+        reset_button.clicked, timeout=DEFAULT_TIMEOUT_MILLIS
+    ):
         reset_button.click()
     assert tuple(qtctrl.contrastLimitsSlider.value()) == original_clims
 
@@ -85,7 +88,9 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     # Surface will not have a "full range button"
     if np.issubdtype(layer.dtype, np.integer):
         info = np.iinfo(layer.dtype)
-        with qtbot.waitSignal(rangebtn.clicked):
+        with qtbot.waitSignal(
+            rangebtn.clicked, timeout=DEFAULT_TIMEOUT_MILLIS
+        ):
             rangebtn.click()
         assert tuple(layer.contrast_limits_range) == (info.min, info.max)
         min_ = qtctrl.contrastLimitsSlider.minimum()

--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -74,8 +74,7 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     reset_button = qtctrl.clim_popup.findChild(
         QPushButton, "reset_clims_button"
     )
-    with qtbot.waitSignal(reset_button.clicked):
-        reset_button.click()
+    reset_button.click()
     assert tuple(qtctrl.contrastLimitsSlider.value()) == original_clims
 
     rangebtn = qtctrl.clim_popup.findChild(
@@ -85,8 +84,7 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     # Surface will not have a "full range button"
     if np.issubdtype(layer.dtype, np.integer):
         info = np.iinfo(layer.dtype)
-        with qtbot.waitSignal(rangebtn.clicked):
-            rangebtn.click()
+        rangebtn.click()
         assert tuple(layer.contrast_limits_range) == (info.min, info.max)
         min_ = qtctrl.contrastLimitsSlider.minimum()
         max_ = qtctrl.contrastLimitsSlider.maximum()

--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -74,8 +74,8 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     reset_button = qtctrl.clim_popup.findChild(
         QPushButton, "reset_clims_button"
     )
-    reset_button.click()
-    qtbot.wait(20)
+    with qtbot.waitSignal(reset_button.clicked):
+        reset_button.click()
     assert tuple(qtctrl.contrastLimitsSlider.value()) == original_clims
 
     rangebtn = qtctrl.clim_popup.findChild(
@@ -85,8 +85,8 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     # Surface will not have a "full range button"
     if np.issubdtype(layer.dtype, np.integer):
         info = np.iinfo(layer.dtype)
-        rangebtn.click()
-        qtbot.wait(20)
+        with qtbot.waitSignal(rangebtn.clicked):
+            rangebtn.click()
         assert tuple(layer.contrast_limits_range) == (info.min, info.max)
         min_ = qtctrl.contrastLimitsSlider.minimum()
         max_ = qtctrl.contrastLimitsSlider.maximum()

--- a/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -12,7 +12,6 @@ from napari._qt.layer_controls.qt_image_controls_base import (
     QtBaseImageControls,
     range_to_decimals,
 )
-from napari._tests.utils import DEFAULT_TIMEOUT_MILLIS
 from napari.layers import Image, Surface
 
 _IMAGE = np.arange(100).astype(np.uint16).reshape((10, 10))
@@ -75,9 +74,7 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     reset_button = qtctrl.clim_popup.findChild(
         QPushButton, "reset_clims_button"
     )
-    with qtbot.waitSignal(
-        reset_button.clicked, timeout=DEFAULT_TIMEOUT_MILLIS
-    ):
+    with qtbot.waitSignal(reset_button.clicked):
         reset_button.click()
     assert tuple(qtctrl.contrastLimitsSlider.value()) == original_clims
 
@@ -88,9 +85,7 @@ def test_range_popup_clim_buttons(mock_show, qtbot, layer):
     # Surface will not have a "full range button"
     if np.issubdtype(layer.dtype, np.integer):
         info = np.iinfo(layer.dtype)
-        with qtbot.waitSignal(
-            rangebtn.clicked, timeout=DEFAULT_TIMEOUT_MILLIS
-        ):
+        with qtbot.waitSignal(rangebtn.clicked):
             rangebtn.click()
         assert tuple(layer.contrast_limits_range) == (info.min, info.max)
         min_ = qtctrl.contrastLimitsSlider.minimum()

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -346,7 +346,7 @@ def combine_widgets(
 
 def add_flash_animation(
     widget: QWidget,
-    duration_millis: int = 300,
+    duration: int = 300,
     color: Array = (0.5, 0.5, 0.5, 0.5),
 ):
     """Add flash animation to widget to highlight certain action (e.g. taking a screenshot).
@@ -355,7 +355,7 @@ def add_flash_animation(
     ----------
     widget : QWidget
         Any Qt widget.
-    duration_millis : int
+    duration : int
         Duration of the flash animation in milliseconds.
     color : Array
         Color of the flash animation. By default, we use light gray.
@@ -380,7 +380,7 @@ def add_flash_animation(
     widget._flash_animation.start()
 
     # now  set an actual time for the flashing and an intermediate color
-    widget._flash_animation.setDuration(duration_millis)
+    widget._flash_animation.setDuration(duration)
     widget._flash_animation.setKeyValueAt(0.1, QColor(*color))
 
 

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -345,7 +345,9 @@ def combine_widgets(
 
 
 def add_flash_animation(
-    widget: QWidget, duration: int = 300, color: Array = (0.5, 0.5, 0.5, 0.5)
+    widget: QWidget,
+    duration_ms: int = 300,
+    color: Array = (0.5, 0.5, 0.5, 0.5),
 ):
     """Add flash animation to widget to highlight certain action (e.g. taking a screenshot).
 
@@ -353,8 +355,8 @@ def add_flash_animation(
     ----------
     widget : QWidget
         Any Qt widget.
-    duration : int
-        Duration of the flash animation.
+    duration_ms : int
+        Duration of the flash animation in milliseconds.
     color : Array
         Color of the flash animation. By default, we use light gray.
     """
@@ -378,7 +380,7 @@ def add_flash_animation(
     widget._flash_animation.start()
 
     # now  set an actual time for the flashing and an intermediate color
-    widget._flash_animation.setDuration(duration)
+    widget._flash_animation.setDuration(duration_ms)
     widget._flash_animation.setKeyValueAt(0.1, QColor(*color))
 
 

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -346,7 +346,7 @@ def combine_widgets(
 
 def add_flash_animation(
     widget: QWidget,
-    duration_ms: int = 300,
+    duration_millis: int = 300,
     color: Array = (0.5, 0.5, 0.5, 0.5),
 ):
     """Add flash animation to widget to highlight certain action (e.g. taking a screenshot).
@@ -355,7 +355,7 @@ def add_flash_animation(
     ----------
     widget : QWidget
         Any Qt widget.
-    duration_ms : int
+    duration_millis : int
         Duration of the flash animation in milliseconds.
     color : Array
         Color of the flash animation. By default, we use light gray.
@@ -380,7 +380,7 @@ def add_flash_animation(
     widget._flash_animation.start()
 
     # now  set an actual time for the flashing and an intermediate color
-    widget._flash_animation.setDuration(duration_ms)
+    widget._flash_animation.setDuration(duration_millis)
     widget._flash_animation.setKeyValueAt(0.1, QColor(*color))
 
 

--- a/napari/_qt/widgets/_tests/test_qt_buttons.py
+++ b/napari/_qt/widgets/_tests/test_qt_buttons.py
@@ -16,7 +16,7 @@ def test_radio_button(qtbot):
     assert btn.toolTip() == 'tooltip'
 
     btn.click()
-    qtbot.waitUntil(lambda: layer.mode == 'add')
+    assert layer.mode == 'add'
 
 
 def test_push_button(qtbot):
@@ -33,4 +33,4 @@ def test_push_button(qtbot):
     assert btn.toolTip() == 'tooltip'
 
     btn.click()
-    qtbot.waitUntil(lambda: layer.test_prop)
+    assert layer.test_prop

--- a/napari/_qt/widgets/_tests/test_qt_buttons.py
+++ b/napari/_qt/widgets/_tests/test_qt_buttons.py
@@ -16,8 +16,7 @@ def test_radio_button(qtbot):
     assert btn.toolTip() == 'tooltip'
 
     btn.click()
-    qtbot.wait(50)
-    assert layer.mode == 'add'
+    qtbot.waitUntil(lambda: layer.mode == 'add')
 
 
 def test_push_button(qtbot):
@@ -34,5 +33,4 @@ def test_push_button(qtbot):
     assert btn.toolTip() == 'tooltip'
 
     btn.click()
-    qtbot.wait(50)
-    assert layer.test_prop
+    qtbot.waitUntil(lambda: layer.test_prop)

--- a/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -279,15 +279,16 @@ def test_play_button(qtbot):
     ndim = 3
     view = QtDims(Dims(ndim=ndim))
     qtbot.addWidget(view)
-    button = view.slider_widgets[0].play_button
-    qtbot.mouseClick(button, Qt.LeftButton)
-    qtbot.waitSignal(view._animation_thread.started, timeout=5000)
+    slider = view.slider_widgets[0]
+    button = slider.play_button
 
-    with qtbot.waitSignal(view._animation_thread.finished, timeout=7000):
+    with qtbot.waitSignal(slider.play_started):
         qtbot.mouseClick(button, Qt.LeftButton)
 
-    qtbot.wait(100)
-    assert not view.is_playing
+    with qtbot.waitSignal(slider.play_stopped, timeout=7000):
+        qtbot.mouseClick(button, Qt.LeftButton)
+
+    qtbot.waitUntil(lambda: not view.is_playing)
 
     with patch.object(button.popup, 'show_above_mouse') as mock_popup:
         qtbot.mouseClick(button, Qt.RightButton)

--- a/napari/_qt/widgets/_tests/test_qt_highlight_preview.py
+++ b/napari/_qt/widgets/_tests/test_qt_highlight_preview.py
@@ -103,10 +103,10 @@ def test_qt_triangle_maximum(triangle_widget):
 def test_qt_triangle_signal(qtbot, triangle_widget):
     widget = triangle_widget()
 
-    with qtbot.waitSignal(widget.valueChanged, timeout=500):
+    with qtbot.waitSignal(widget.valueChanged):
         widget.setValue(7)
 
-    with qtbot.waitSignal(widget.valueChanged, timeout=500):
+    with qtbot.waitSignal(widget.valueChanged):
         widget.setValue(-5)
 
 
@@ -232,8 +232,8 @@ def test_qt_highlight_size_preview_widget_signal(
 ):
     widget = highlight_size_preview_widget()
 
-    with qtbot.waitSignal(widget.valueChanged, timeout=500):
+    with qtbot.waitSignal(widget.valueChanged):
         widget.setValue(7)
 
-    with qtbot.waitSignal(widget.valueChanged, timeout=500):
+    with qtbot.waitSignal(widget.valueChanged):
         widget.setValue(-5)

--- a/napari/_qt/widgets/_tests/test_qt_play.py
+++ b/napari/_qt/widgets/_tests/test_qt_play.py
@@ -122,14 +122,10 @@ def test_play_raises_index_errors(qtbot, ref_view):
     # play axis is out of range
     with pytest.raises(IndexError):
         view.dims.play(4, 20)
-        qtbot.wait(20)
-        view.dims.stop()
 
     # data doesn't have 20 frames
     with pytest.raises(IndexError):
         view.dims.play(0, 20, frame_range=[2, 20])
-        qtbot.wait(20)
-        view.dims.stop()
 
 
 def test_play_raises_value_errors(qtbot, ref_view):
@@ -137,14 +133,10 @@ def test_play_raises_value_errors(qtbot, ref_view):
     # frame_range[1] not > frame_range[0]
     with pytest.raises(ValueError):
         view.dims.play(0, 20, frame_range=[2, 2])
-        qtbot.wait(20)
-        view.dims.stop()
 
     # that's not a valid loop_mode
     with pytest.raises(ValueError):
         view.dims.play(0, 20, loop_mode=5)
-        qtbot.wait(20)
-        view.dims.stop()
 
 
 @pytest.mark.skip(reason="fails too often... tested indirectly elsewhere")
@@ -160,18 +152,12 @@ def test_play_api(qtbot, ref_view):
 
     view.dims.dims.events.current_step.connect(increment)
 
-    view.dims.play(0, 20)
     # wait for the thread to start before timing...
-    qtbot.waitSignal(view.dims._animation_thread.started, timeout=10000)
-    qtbot.wait(370)
+    with qtbot.waitSignal(view.dims._animation_thread.started, timeout=10000):
+        view.dims.play(0, 20)
+    qtbot.waitUntil(lambda: view.dims._frame >= 2)
     with qtbot.waitSignal(view.dims._animation_thread.finished, timeout=7000):
         view.dims.stop()
-    A = view.dims._frame
-    assert A >= 3
-
-    # make sure the stop button actually worked
-    qtbot.wait(150)
-    assert A == view.dims._frame
 
 
 def test_playing_hidden_slider_does_nothing(ref_view):

--- a/napari/_qt/widgets/_tests/test_qt_size_preview.py
+++ b/napari/_qt/widgets/_tests/test_qt_size_preview.py
@@ -168,8 +168,8 @@ def test_qt_size_slider_preview_widget_value_invalid(
 def test_qt_size_slider_preview_signal(qtbot, font_size_preview_widget):
     widget = font_size_preview_widget()
 
-    with qtbot.waitSignal(widget.valueChanged, timeout=500):
+    with qtbot.waitSignal(widget.valueChanged):
         widget.setValue(7)
 
-    with qtbot.waitSignal(widget.valueChanged, timeout=500):
+    with qtbot.waitSignal(widget.valueChanged):
         widget.setValue(-5)

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -31,6 +31,11 @@ skip_local_popups = pytest.mark.skipif(
     ' Set NAPARI_POPUP_TESTS=1 environment variable to enable.',
 )
 
+"""
+The default timeout duration in seconds when waiting on tasks running in non-main threads.
+The value was chosen to be consistent with `QtBot.waitSignal` and `QtBot.waitUntil`.
+"""
+DEFAULT_TIMEOUT_SECS: float = 5
 
 """
 Used as pytest params for testing layer add and view functionality (Layer class, data, ndim)

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -52,6 +52,8 @@ def test_visibility_consistency(qtbot, make_napari_viewer):
     layer = viewer.add_image(
         np.random.random((200, 200)), contrast_limits=[0, 10]
     )
+    # TODO: what are we waiting for. Is there a Qt signal we could
+    # equivalently wait for?
     qtbot.wait(10)
     layer.contrast_limits = (0, 2)
     screen1 = viewer.screenshot(flash=False).astype('float')

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -52,8 +52,8 @@ def test_visibility_consistency(qtbot, make_napari_viewer):
     layer = viewer.add_image(
         np.random.random((200, 200)), contrast_limits=[0, 10]
     )
-    # TODO: what are we waiting for. Is there a Qt signal we could
-    # equivalently wait for?
+    # TODO: what are we waiting for. Is there a signal or condition
+    # we could equivalently wait for?
     qtbot.wait(10)
     layer.contrast_limits = (0, 2)
     screen1 = viewer.screenshot(flash=False).astype('float')

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -581,6 +581,8 @@ def test_active_layer_status_update():
     assert len(viewer.layers) == 2
     assert viewer.layers.selection.active == viewer.layers[1]
 
+    # TODO: consider removing throttling for this test, or find/add
+    # some way in psygnal to wait for some signal (e.g. viewer.events.status).
     # wait 1 s to avoid the cursor event throttling
     time.sleep(1)
     viewer.cursor.position = [1, 1, 1, 1, 1]

--- a/napari/utils/_tests/test_magicgui.py
+++ b/napari/utils/_tests/test_magicgui.py
@@ -6,7 +6,7 @@ import pytest
 from magicgui import magicgui
 
 from napari import Viewer, layers, types
-from napari._tests.utils import layer_test_data
+from napari._tests.utils import DEFAULT_TIMEOUT_SECS, layer_test_data
 from napari.layers import Image, Labels, Layer
 from napari.utils._proxies import PublicOnlyProxy
 from napari.utils.misc import all_subclasses
@@ -76,7 +76,7 @@ def test_magicgui_add_future_data(make_napari_viewer, LayerType, data, ndim):
     assert len(viewer.layers) == 0
 
     future = add_data()
-    future.result()
+    future.result(timeout=DEFAULT_TIMEOUT_SECS)
 
     assert len(viewer.layers) == 1
     assert isinstance(viewer.layers[0], LayerType)

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -1,6 +1,5 @@
 import sys
 import threading
-import time
 import warnings
 from typing import List
 
@@ -112,11 +111,9 @@ def test_notification_manager_no_gui_with_threading():
     """
 
     def _warn():
-        time.sleep(0.01)
         warnings.showwarning('this is a warning', UserWarning, '', 0)
 
     def _raise():
-        time.sleep(0.01)
         with pytest.raises(PurposefulException):
             raise PurposefulException("this is an exception")
 
@@ -135,7 +132,7 @@ def test_notification_manager_no_gui_with_threading():
 
         exception_thread = threading.Thread(target=_raise)
         exception_thread.start()
-        time.sleep(0.02)
+        exception_thread.join()
 
         try:
             raise ValueError("a")
@@ -149,16 +146,10 @@ def test_notification_manager_no_gui_with_threading():
         assert warnings.showwarning == notification_manager.receive_warning
         warning_thread = threading.Thread(target=_warn)
         warning_thread.start()
+        warning_thread.join()
 
-        for _ in range(100):
-            time.sleep(0.01)
-            if (
-                len(notification_manager.records) == 2
-                and store[-1].type == 'warning'
-            ):
-                break
-        else:
-            raise AssertionError("Thread notification not received in time")
+        assert len(notification_manager.records) == 2
+        assert store[-1].type == 'warning'
 
     # make sure we've restored the threading except hook
     assert threading.excepthook == previous_threading_exhook

--- a/napari/utils/_tests/test_notification_manager.py
+++ b/napari/utils/_tests/test_notification_manager.py
@@ -5,6 +5,7 @@ from typing import List
 
 import pytest
 
+from napari._tests.utils import DEFAULT_TIMEOUT_SECS
 from napari.utils.notifications import (
     Notification,
     notification_manager,
@@ -132,7 +133,7 @@ def test_notification_manager_no_gui_with_threading():
 
         exception_thread = threading.Thread(target=_raise)
         exception_thread.start()
-        exception_thread.join()
+        exception_thread.join(timeout=DEFAULT_TIMEOUT_SECS)
 
         try:
             raise ValueError("a")
@@ -146,7 +147,7 @@ def test_notification_manager_no_gui_with_threading():
         assert warnings.showwarning == notification_manager.receive_warning
         warning_thread = threading.Thread(target=_warn)
         warning_thread.start()
-        warning_thread.join()
+        warning_thread.join(timeout=DEFAULT_TIMEOUT_SECS)
 
         assert len(notification_manager.records) == 2
         assert store[-1].type == 'warning'


### PR DESCRIPTION
# Description

A draft PR to try to remove some wait/sleep calls in tests.

TODO: define a default timeout for `qtbot.waitSignal` and `qtbot.waitUntil` and use it everywhere.