### PR TITLE
[WIP] Discuss and accept async slicing NAP

### DIFF
--- a/docs/naps/4-async-slicing.md
+++ b/docs/naps/4-async-slicing.md
@@ -483,6 +483,12 @@ class ViewerModel:
         self._slicer.slice_layers_async(self.layers, self.dims)
 ```
 
+Initially we intend for each instance of `ViewerModel` to own a single
+instance of a `LayerSlicer` for the lifetime of that `ViewerModel` instance.
+That allows the `LayerSlicer` to coordinate slicing of any or all layers
+for a particular viewer instance, while allowing multiple viewer instances
+to slice independently.
+
 The main response to the slice being ready occurs on the `QtViewer`
 because `QtViewer.layer_to_visual` provides a way to map from
 a layer to its corresponding vispy layer.

--- a/docs/naps/4-async-slicing.md
+++ b/docs/naps/4-async-slicing.md
@@ -1,6 +1,6 @@
 (nap-4-async-slicing)=
 
-# NAP-4: asynchronous slicing
+# NAP-4: Asynchronous slicing
 
 ```{eval-rst}
 :Author: Andy Sweet <andrewdsweet@gmail.com>, Jun Xi Ni, Eric Perlman, Kim Pevey

--- a/docs/naps/4-async-slicing.md
+++ b/docs/naps/4-async-slicing.md
@@ -326,6 +326,8 @@ class ImageSliceResponse(LayerSliceResponse)
 
 As napari supports RGB and multi-scale images, we need a few more inputs to
 know what data should be accessed to generate the desired slice for the canvas.
+And the thumbnail needs to access the layer data as well, so should do so while
+we are slicing asynchronous to avoid any blocking behavior.
 
 The points request and response types should look something like the following.
 
@@ -333,10 +335,10 @@ The points request and response types should look something like the following.
 class PointsSliceRequest(LayerSliceRequest):
     out_of_slice_display: bool
     size: np.ndarray
+    shown: np.ndarray
     face_color: np.ndarray
     edge_color: np.ndarray
     edge_width: np.ndarray
-    shown: np.ndarray
 
 class PointsSliceResponse(LayerSliceResponse):
     indices: np.ndarray

--- a/docs/naps/4-async-slicing.md
+++ b/docs/naps/4-async-slicing.md
@@ -186,7 +186,7 @@ solutions for this project may cause this state to be read and write from multip
 Rather than exhaustively list all of the slice state of all layer types and their dependencies [^slice-class-diagram],
 we group and highlight some of the more important state.
 
-### Input state
+#### Input state
 
 Some input state for slicing is directly mutated by `Layer._slice_dims`. 
 

--- a/docs/naps/4-async-slicing.md
+++ b/docs/naps/4-async-slicing.md
@@ -5,8 +5,11 @@
 ```{eval-rst}
 :Author: Andy Sweet <andrewdsweet@gmail.com>, Jun Xi Ni, Eric Perlman, Kim Pevey
 :Created: 2022-06-23
-:Status: Draft
+:Resolution: TODO <url>
+:Resolved: TODO <yyyy-mm-dd>
+:Status: Accepted
 :Type: Standards Track
+:Version effective: 0.5
 ```
 
 ## Abstract


### PR DESCRIPTION
This is a work-in-progress PR that updates the async slicing NAP with some decisions on the critical discussion points. It also adds some clarification about backwards compatibility and the implementation plan now that those are a little clearer. Finally it changes the status from Draft to Accepted.

One last point that would be good to address before opening a PR on the main repo is [Nick's point around firming up the specific API we're proposing](https://napari.zulipchat.com/#narrow/stream/322105-naps/topic/NAP-4.3A.20async.20slicing/near/291923964) even if that's not public. I think if we can do this for the Image, Labels, and Points layers that should be enough. Given the proposed incremental/non-breaking/mostly-private implementation plan, I think I would be fine just stating the API in the prototype, knowing that it might change a little as we progress through the implementation.