### PR TITLE
[WIP] Integrate image slice request with layer slicer

### DIFF
--- a/napari/layers/utils/_slice_input.py
+++ b/napari/layers/utils/_slice_input.py
@@ -62,7 +62,7 @@ class _SliceInput:
 
     def data_indices(
         self, world_to_data: Affine, round_index: bool = True
-    ) -> Tuple[Union[int, float, slice]]:
+    ) -> Tuple[Union[int, float, slice], ...]:
         """Transforms this into indices that can be used to slice layer data.
 
         The elements in non-displayed dimensions will be real numbers.


### PR DESCRIPTION
This integrates #5259 with #5170 and adds tests to show that `LayerSlicer` can be used to asynchronously slice images.