### PR TITLE
Refactor layer's editable property and reset method

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -517,29 +517,37 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         self.events.blending()
 
     @property
-    def visible(self):
+    def visible(self) -> bool:
         """bool: Whether the visual is currently being displayed."""
         return self._visible
 
     @visible.setter
-    def visible(self, visibility):
+    def visible(self, visibility: bool):
         self._visible = visibility
         self.refresh()
         self.events.visible()
-        self.editable = self._set_editable() if self.visible else False
+        self.editable = visibility
 
     @property
-    def editable(self):
+    def editable(self) -> bool:
         """bool: Whether the current layer data is editable from the viewer."""
         return self._editable
 
     @editable.setter
-    def editable(self, editable):
+    def editable(self, editable: bool):
         if self._editable == editable:
             return
         self._editable = editable
-        self._set_editable(editable=editable)
+        self._on_editable_changed()
         self.events.editable()
+
+    def _reset_editable(self) -> None:
+        """Reset this layer's editable state based on layer properties."""
+        self.editable = True
+
+    def _on_editable_changed(self) -> None:
+        """Executes side-effects on this layer related to changes of the editable state."""
+        pass
 
     @property
     def scale(self):
@@ -736,10 +744,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     def _get_ndim(self):
         raise NotImplementedError()
 
-    def _set_editable(self, editable=None):
-        if editable is None:
-            self.editable = True
-
     def _get_base_state(self):
         """Get dictionary of attributes on base layer.
 
@@ -921,7 +925,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         # Update the point values
         self._update_dims()
-        self._set_editable()
+        self._reset_editable()
 
     def _make_slice_input(
         self, point=None, ndisplay=2, order=None

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -464,7 +464,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         self.events.data(value=self.data)
         if self._keep_auto_contrast:
             self.reset_contrast_limits()
-        self._set_editable()
+        self._reset_editable()
 
     def _get_ndim(self):
         """Determine number of dimensions of the layer."""

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -308,7 +308,7 @@ class Labels(_ImageBase):
 
         # Trigger generation of view slice and thumbnail
         self._update_dims()
-        self._set_editable()
+        self._reset_editable()
 
     @property
     def rendering(self):
@@ -430,7 +430,7 @@ class Labels(_ImageBase):
         self._data = data
         self._update_dims()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     @property
     def features(self):
@@ -756,11 +756,10 @@ class Labels(_ImageBase):
             )
         self._contrast_limits = (0, 1)
 
-    def _set_editable(self, editable=None):
-        """Set editable mode based on layer properties."""
-        if editable is None:
-            self.editable = not self.multiscale
+    def _reset_editable(self, editable: Optional[bool] = None) -> None:
+        self.editable = not self.multiscale
 
+    def _on_editable_changed(self) -> None:
         if not self.editable:
             self.mode = Mode.PAN_ZOOM
             self._reset_history()

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -541,7 +541,7 @@ class Points(Layer):
 
         self._update_dims()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     def _on_selection(self, selected):
         if selected:
@@ -1456,17 +1456,16 @@ class Points(Layer):
         """
         return self.edge_color[self._indices_view]
 
-    def _set_editable(self, editable=None):
+    def _reset_editable(self) -> None:
         """Set editable mode based on layer properties."""
-        if editable is None:
-            self.editable = True
+        # interaction currently does not work for 2D layers being rendered in 3D
+        self.editable = not (
+            self.ndim == 2 and self._slice_input.ndisplay == 3
+        )
+
+    def _on_editable_changed(self) -> None:
         if not self.editable:
             self.mode = Mode.PAN_ZOOM
-
-        if self.ndim < 3 and self._slice_input.ndisplay == 3:
-            # interaction currently does not work for 2D
-            # layers being rendered in 3D.
-            self.editable = False
 
     def _slice_data(
         self, dims_indices

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -666,7 +666,7 @@ class Shapes(Layer):
 
         self._update_dims()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     def _on_selection(self, selected: bool):
         # this method is slated for removal.  don't add anything new.
@@ -1625,14 +1625,10 @@ class Shapes(Layer):
             else:
                 self.refresh()
 
-    def _set_editable(self, editable=None):
-        """Set editable mode based on layer properties."""
-        if editable is None:
-            if self._slice_input.ndisplay == 3:
-                self.editable = False
-            else:
-                self.editable = True
+    def _reset_editable(self) -> None:
+        self.editable = self._slice_input.ndisplay == 2
 
+    def _on_editable_changed(self) -> None:
         if not self.editable:
             self.mode = Mode.PAN_ZOOM
 

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -269,6 +269,7 @@ class Surface(IntensityVisualizationMixin, Layer):
 
         self._update_dims()
         self.events.data(value=self.data)
+        self._reset_editable()
         if self._keep_auto_contrast:
             self.reset_contrast_limits()
 

--- a/napari/layers/surface/surface.py
+++ b/napari/layers/surface/surface.py
@@ -285,7 +285,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         self._update_dims()
         self.refresh()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     @property
     def vertex_values(self) -> np.ndarray:
@@ -299,7 +299,7 @@ class Surface(IntensityVisualizationMixin, Layer):
 
         self.refresh()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     @property
     def faces(self) -> np.ndarray:
@@ -313,7 +313,7 @@ class Surface(IntensityVisualizationMixin, Layer):
 
         self.refresh()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     def _get_ndim(self):
         """Determine number of dimensions of the layer."""

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -388,7 +388,7 @@ class Tracks(Layer):
         self.events.rebuild_tracks()
         self.events.rebuild_graph()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     @property
     def features(self):

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -280,7 +280,7 @@ class Vectors(Layer):
 
         self._update_dims()
         self.events.data(value=self.data)
-        self._set_editable()
+        self._reset_editable()
 
     @property
     def features(self):


### PR DESCRIPTION
# Description
This refactors the `Layer.editable` property and `Layer._set_editable` helper method. The attempt is to clarify and simplify what these things do.

We may also be able to fix https://github.com/napari/napari/issues/1346 in this PR, though I haven't tried that yet.

In general, I'm a bit confused why we reset the editable state so often. I'm also wondering if it should be partially derived.
