### PR TITLE
[WIP] Define base layer slice request and response

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -2,7 +2,7 @@ import gc
 import os
 import weakref
 from dataclasses import dataclass
-from typing import List
+from typing import List, Union
 from unittest import mock
 
 import numpy as np
@@ -10,7 +10,9 @@ import pytest
 from imageio import imread
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import QMessageBox
+from vispy.visuals import VolumeVisual
 
+from napari import Viewer
 from napari._qt.qt_viewer import QtViewer
 from napari._tests.utils import (
     add_layer_by_type,
@@ -19,10 +21,12 @@ from napari._tests.utils import (
     skip_local_popups,
     skip_on_win_ci,
 )
+from napari._vispy.layers.image import VispyImageLayer
 from napari._vispy.utils.gl import fix_data_dtype
 from napari.components.viewer_model import ViewerModel
 from napari.layers import Points
 from napari.settings import get_settings
+from napari.utils.events import Event
 from napari.utils.interactions import mouse_press_callbacks
 from napari.utils.theme import available_themes
 
@@ -677,3 +681,123 @@ def test_create_non_empty_viewer_model(qtbot):
     del viewer
     qtbot.wait(50)
     gc.collect()
+
+
+# The following are integration tests for the new style of slicing.
+# They are marked with sync_only because that denotes that the old experimental
+# async should not run as we don't explicitly wait for its threads to finish.
+
+
+@pytest.mark.sync_only
+def test_async_slice_image_on_current_step_change(make_napari_viewer, qtbot):
+    np.random.seed(0)
+    data = np.random.rand(3, 4, 5)
+    viewer = make_napari_viewer()
+    vispy_image = setup_viewer_for_async_slice_image(viewer, data)
+    assert viewer.dims.current_step != (2, 0, 0)
+
+    viewer.dims.current_step = (2, 0, 0)
+
+    wait_until_vispy_image_data_equal(qtbot, vispy_image, data[2, :, :])
+
+
+@pytest.mark.sync_only
+def test_async_slice_image_on_order_change(make_napari_viewer, qtbot):
+    np.random.seed(0)
+    data = np.random.rand(3, 4, 5)
+    viewer = make_napari_viewer()
+    vispy_image = setup_viewer_for_async_slice_image(viewer, data)
+    assert viewer.dims.order != (1, 0, 2)
+
+    viewer.dims.order = (1, 0, 2)
+
+    wait_until_vispy_image_data_equal(qtbot, vispy_image, data[:, 2, :])
+
+
+@pytest.mark.sync_only
+def test_async_slice_image_on_ndisplay_change(make_napari_viewer, qtbot):
+    np.random.seed(0)
+    data = np.random.rand(3, 4, 5)
+    viewer = make_napari_viewer()
+    vispy_image = setup_viewer_for_async_slice_image(viewer, data)
+    assert viewer.dims.ndisplay != 3
+
+    viewer.dims.ndisplay = 3
+
+    wait_until_vispy_image_data_equal(qtbot, vispy_image, data)
+
+
+@pytest.mark.sync_only
+def test_async_slice_multiscale_image_on_pan(make_napari_viewer, qtbot):
+    viewer = make_napari_viewer()
+    np.random.seed(0)
+    data = [np.random.rand(4, 8, 10), np.random.rand(2, 4, 5)]
+    vispy_image = setup_viewer_for_async_slice_image(viewer, data)
+
+    # Check that we're initially slicing the middle of the first dimension
+    # over the whole of lowest resolution image.
+    assert viewer.dims.not_displayed == (0,)
+    assert viewer.dims.current_step[0] == 2
+    image = vispy_image.layer
+    assert image._data_level == 1
+    np.testing.assert_equal(image.corner_pixels, [[0, 0, 0], [0, 4, 5]])
+
+    # Simulate panning to the left by changing the corner pixels in the last
+    # dimension, which corresponds to x/columns, then triggering a reslice.
+    image.corner_pixels = np.array([[0, 0, 0], [0, 4, 3]])
+    image.events.reslice(Event('reslice', layer=image))
+
+    wait_until_vispy_image_data_equal(qtbot, vispy_image, data[1][1, 0:4, 0:3])
+
+
+@pytest.mark.sync_only
+def test_async_slice_multiscale_image_on_zoom(qtbot, make_napari_viewer):
+    viewer = make_napari_viewer()
+    np.random.seed(0)
+    data = [np.random.rand(4, 8, 10), np.random.rand(2, 4, 5)]
+    vispy_image = setup_viewer_for_async_slice_image(viewer, data)
+
+    # Check that we're initially slicing the middle of the first dimension
+    # over the whole of lowest resolution image.
+    assert viewer.dims.not_displayed == (0,)
+    assert viewer.dims.current_step[0] == 2
+    image = vispy_image.layer
+    assert image._data_level == 1
+    np.testing.assert_equal(image.corner_pixels, [[0, 0, 0], [0, 4, 5]])
+
+    # Simulate zooming into the middle of the higher resolution image.
+    image._data_level = 0
+    image.corner_pixels = np.array([[0, 2, 3], [0, 6, 7]])
+    image.events.reslice(Event('reslice', layer=image))
+
+    wait_until_vispy_image_data_equal(qtbot, vispy_image, data[0][2, 2:6, 3:7])
+
+
+def setup_viewer_for_async_slice_image(
+    viewer: Viewer,
+    data: Union[np.ndarray, List[np.ndarray]],
+) -> VispyImageLayer:
+    # Initially force synchronous slicing so any slicing caused
+    # by adding the image finishes before any other slicing starts.
+    viewer._layer_slicer._force_sync = True
+    # Add the image and get the corresponding vispy image.
+    layer = viewer.add_image(data)
+    vispy_layer = viewer.window._qt_viewer.layer_to_visual[layer]
+    # Then allow asynchronous slicing for testing.
+    viewer._layer_slicer._force_sync = False
+    return vispy_layer
+
+
+def wait_until_vispy_image_data_equal(
+    qtbot, vispy_layer: VispyImageLayer, expected_data: np.ndarray
+) -> None:
+    def assert_vispy_image_data_equal() -> None:
+        node = vispy_layer.node
+        data = (
+            node._last_data if isinstance(node, VolumeVisual) else node._data
+        )
+        # Vispy node data may have been post-processed (e.g. through a colormap),
+        # so check that values are close rather than exactly equal.
+        np.testing.assert_allclose(data, expected_data)
+
+    qtbot.waitUntil(assert_vispy_image_data_equal)

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -11,6 +11,7 @@ import numpy as np
 from qtpy.QtCore import QCoreApplication, QObject, Qt
 from qtpy.QtGui import QCursor, QGuiApplication
 from qtpy.QtWidgets import QFileDialog, QSplitter, QVBoxLayout, QWidget
+from superqt import ensure_main_thread
 
 from napari._qt.containers import QtLayerList
 from napari._qt.dialogs.qt_reader_dialog import handle_gui_reading
@@ -247,6 +248,8 @@ class QtViewer(QSplitter):
             'pointing': Qt.CursorShape.PointingHandCursor,
             'standard': Qt.CursorShape.ArrowCursor,
         }
+
+        self.viewer._layer_slicer.events.ready.connect(self._on_slice_ready)
 
         self._on_active_change()
         self.viewer.layers.events.inserted.connect(self._update_welcome_screen)
@@ -522,6 +525,19 @@ class QtViewer(QSplitter):
         if console is not None:
             self.dockConsole.setWidget(console)
             console.setParent(self.dockConsole)
+
+    @ensure_main_thread
+    def _on_slice_ready(self, event):
+        responses = event.value
+        for layer, response in responses.items():
+            # Update the layer slice state to temporarily support behavior
+            # that depends on it.
+            layer._update_slice_response(response)
+            # The rest of `Layer.refresh` after `set_view_slice`, where `set_data`
+            # notifies the corresponding vispy layer of the new slice.
+            layer.events.set_data()
+            layer._update_thumbnail()
+            layer._set_highlight(force=True)
 
     def _on_active_change(self):
         """When active layer changes change keymap handler."""

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -81,6 +81,7 @@ class _LayerSlicer:
     @contextmanager
     def force_sync(self):
         """Context manager to temporarily force slicing to be synchronous.
+
         This should only be used from the main thread.
 
         >>> layer_slicer = _LayerSlicer()

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -239,7 +239,7 @@ class _LayerSlicer:
 
     def _find_existing_task(
         self, layers: Iterable[Layer]
-    ) -> Optional[Future[dict]]:
+    ) -> Optional[Future[Dict]]:
         """Find the task associated with a list of layers. Returns the first
         task found for which the layers of the task are a subset of the input
         layers.

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -105,6 +105,8 @@ class _LayerSlicer:
         replaced the new ones. If multiple layers are sliced, any task that contains
         only one of those layers can safely be cancelled. If a single layer is sliced,
         it will wait for any existing tasks that include that layer AND another layer,
+        In other words, it will only cancel if the new task will replace the
+        slices of all the layers in the pending task.
 
         This should only be called from the main thread.
 

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -61,7 +61,6 @@ class _LayerSlicer:
         >>> layer = Image(...)  # an async-ready layer
         >>> with layer_slice.force_sync():
         >>>     layer_slicer.submit(layers=[layer], dims=Dims())
-        >>>     layer_slicer.submit(layers=[layer], dims=Dims())
         """
         prev = self._force_sync
         self._force_sync = True
@@ -101,18 +100,11 @@ class _LayerSlicer:
         """Slices the given layers with the given dims.
 
         Submitting multiple layers at one generates multiple requests, but only ONE task.
-        Submitting multiple layers at one generates multiple requests, but only ONE task.
 
         This will attempt to cancel all pending slicing tasks that can be entirely
         replaced the new ones. If multiple layers are sliced, any task that contains
         only one of those layers can safely be cancelled. If a single layer is sliced,
         it will wait for any existing tasks that include that layer AND another layer,
-        This will attempt to cancel all pending slicing tasks that can be entirely
-        replaced the new ones. If multiple layers are sliced, any task that contains
-        only one of those layers can safely be cancelled. If a single layer is sliced,
-        it will wait for any existing tasks that include that layer AND another layer,
-        In other words, it will only cancel if the new task will replace the
-        slices of all the layers in the pending task.
 
         This should only be called from the main thread.
 

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -14,31 +14,11 @@ from napari.layers import Image, Points
 from napari.layers._data_protocols import Index, LayerDataProtocol
 from napari.types import DTypeLike
 
-"""
-Cases to consider
-- single + multiple layers that supports async (all of layers do support async)
-- single + multiple layers that don't support async (all of layers do not support async)
-- mix of layers that do and don't support async
-
-Behaviors we want to test:
-scheduling logic of the slicer (and not correctness of the slice response value)
-
-- for layers that support async, the slice task should not be run on the main
-  thread (we don't want to block the calling)
-- for layers that do not support async, slicing should always be done once
-  the method returns
-- slice requests should be run on the main thread
-- pending tasks are cancelled (at least when the new task will slice all
-  layers for the pending task)
-
-The fake request, response, and layers exist to give structure against which to
-test (class instances and attributes) and to remain isolated from the existing
-codebase. They represent what will become real classes in the codebase which
-have additional methods and properties that don't currently exist.
-
-Run all tests with:
-pytest napari/components/_tests/test_layer_slicer.py -svv
-"""
+# The following fakes are used to control execution of slicing across
+# multiple threads, while also allowing us to mimic real classes
+# (like layers) in the code base. This allows us to assert state and
+# conditions that may only be temporarily true at different stages of
+# an asynchronous task.
 
 
 @dataclass(frozen=True)

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -58,13 +58,17 @@ class FakeSliceRequest:
 
 class FakeAsyncLayer:
     def __init__(self):
-        self.slice_count = 0
-        self.lock = RLock()
+        self._slice_request_count: int = 0
+        self.slice_count: int = 0
+        self.lock: RLock = RLock()
 
-    def _make_slice_request(self, dims) -> FakeSliceRequest:
+    def _make_slice_request(self, dims: Dims) -> FakeSliceRequest:
         assert current_thread() == main_thread()
-        self.slice_count += 1
-        return FakeSliceRequest(id=self.slice_count, lock=self.lock)
+        self._slice_request_count += 1
+        return FakeSliceRequest(id=self._slice_request_count, lock=self.lock)
+
+    def _update_slice_response(self, response: FakeSliceResponse):
+        self.slice_count = response.id
 
     def _slice_dims(self, *args, **kwargs) -> None:
         self.slice_count += 1
@@ -114,27 +118,25 @@ def layer_slicer():
     layer_slicer.shutdown()
 
 
-def test_slice_layers_async_with_one_async_layer_no_block(layer_slicer):
+def test_submit_with_one_async_layer_no_block(layer_slicer):
     layer = FakeAsyncLayer()
 
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert future.result()[layer].id == 1
 
 
-def test_slice_layers_async_with_multiple_async_layer_no_block(layer_slicer):
+def test_submit_with_multiple_async_layer_no_block(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeAsyncLayer()
 
-    future = layer_slicer.slice_layers_async(
-        layers=[layer1, layer2], dims=Dims()
-    )
+    future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
     assert future.result()[layer1].id == 1
     assert future.result()[layer2].id == 1
 
 
-def test_slice_layers_async_emits_ready_event_when_done(layer_slicer):
+def test_submit_emits_ready_event_when_done(layer_slicer):
     layer = FakeAsyncLayer()
     event_result = None
 
@@ -144,74 +146,69 @@ def test_slice_layers_async_emits_ready_event_when_done(layer_slicer):
 
     layer_slicer.events.ready.connect(on_done)
 
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
     actual_result = future.result()
 
     assert actual_result is event_result
 
 
-def test_slice_layers_async_with_one_sync_layer(layer_slicer):
+def test_submit_with_one_sync_layer(layer_slicer):
     layer = FakeSyncLayer()
     assert layer.slice_count == 0
 
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert future is None
 
 
-def test_slice_layers_async_with_multiple_sync_layer(layer_slicer):
+def test_submit_with_multiple_sync_layer(layer_slicer):
     layer1 = FakeSyncLayer()
     layer2 = FakeSyncLayer()
     assert layer1.slice_count == 0
     assert layer2.slice_count == 0
 
-    future = layer_slicer.slice_layers_async(
-        layers=[layer1, layer2], dims=Dims()
-    )
+    future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
     assert layer1.slice_count == 1
     assert layer2.slice_count == 1
-    assert not future.result()
+    assert future is None
 
 
-def test_slice_layers_async_with_mixed_layers(layer_slicer):
+def test_submit_with_mixed_layers(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeSyncLayer()
     assert layer1.slice_count == 0
     assert layer2.slice_count == 0
 
-    future = layer_slicer.slice_layers_async(
-        layers=[layer1, layer2], dims=Dims()
-    )
+    future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
-    assert layer1.slice_count == 1
     assert layer2.slice_count == 1
     assert future.result()[layer1].id == 1
     assert layer2 not in future.result()
 
 
-def test_slice_layers_async_lock_blocking(layer_slicer):
+def test_submit_lock_blocking(layer_slicer):
     dims = Dims()
     layer = FakeAsyncLayer()
 
     assert layer.slice_count == 0
     with layer.lock:
-        blocked = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        blocked = layer_slicer.submit(layers=[layer], dims=dims)
         assert not blocked.done()
 
     assert blocked.result()[layer].id == 1
 
 
-def test_slice_layers_async_multiple_calls_cancels_pending(layer_slicer):
+def test_submit_multiple_calls_cancels_pending(layer_slicer):
     dims = Dims()
     layer = FakeAsyncLayer()
 
     with layer.lock:
-        blocked = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
-        pending = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        blocked = layer_slicer.submit(layers=[layer], dims=dims)
+        pending = layer_slicer.submit(layers=[layer], dims=dims)
         assert not pending.running()
-        layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        layer_slicer.submit(layers=[layer], dims=dims)
         assert not blocked.done()
 
     assert pending.cancelled()
@@ -223,8 +220,8 @@ def test_slice_layers_mixed_allows_sync_to_run(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeSyncLayer()
     with layer1.lock:
-        blocked = layer_slicer.slice_layers_async(layers=[layer1], dims=dims)
-        layer_slicer.slice_layers_async(layers=[layer2], dims=dims)
+        blocked = layer_slicer.submit(layers=[layer1], dims=dims)
+        layer_slicer.submit(layers=[layer2], dims=dims)
         assert layer2.slice_count == 1
         assert not blocked.done()
 
@@ -237,9 +234,7 @@ def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
     layer1 = FakeAsyncLayer()
     layer2 = FakeSyncLayer()
     with layer1.lock:
-        blocked = layer_slicer.slice_layers_async(
-            layers=[layer1, layer2], dims=dims
-        )
+        blocked = layer_slicer.submit(layers=[layer1, layer2], dims=dims)
 
         assert layer2.slice_count == 1
         assert not blocked.done()
@@ -247,7 +242,7 @@ def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
     assert blocked.result()[layer1].id == 1
 
 
-def test_slice_layers_async_with_multiple_async_layer_with_all_locked(
+def test_submit_with_multiple_async_layer_with_all_locked(
     layer_slicer,
 ):
     """ensure that if only all layers are locked, none continue"""
@@ -256,23 +251,21 @@ def test_slice_layers_async_with_multiple_async_layer_with_all_locked(
     layer2 = FakeAsyncLayer()
 
     with layer1.lock, layer2.lock:
-        blocked = layer_slicer.slice_layers_async(
-            layers=[layer1, layer2], dims=dims
-        )
+        blocked = layer_slicer.submit(layers=[layer1, layer2], dims=dims)
         assert not blocked.done()
 
     assert blocked.result()[layer1].id == 1
     assert blocked.result()[layer2].id == 1
 
 
-def test_slice_layers_async_task_to_layers_lock(layer_slicer):
+def test_submit_task_to_layers_lock(layer_slicer):
     """ensure that if only one layer has a lock, the non-locked layer
     can continue"""
     dims = Dims()
     layer = FakeAsyncLayer()
 
     with layer.lock:
-        task = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        task = layer_slicer.submit(layers=[layer], dims=dims)
         assert task in layer_slicer._layers_to_task.values()
 
     assert task.result()[layer].id == 1
@@ -289,7 +282,7 @@ def test_slice_layers_exception_main_thread(layer_slicer):
 
     layer = FakeAsyncLayerError()
     with pytest.raises(RuntimeError, match='_make_slice_request'):
-        layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+        layer_slicer.submit(layers=[layer], dims=Dims())
 
 
 def test_slice_layers_exception_subthread_on_result(layer_slicer):
@@ -303,11 +296,14 @@ def test_slice_layers_exception_subthread_on_result(layer_slicer):
             raise RuntimeError('FakeSliceRequestError')
 
     class FakeAsyncLayerError(FakeAsyncLayer):
-        def _make_slice_request(self, dims) -> FakeSliceRequestError:
-            return FakeSliceRequestError(id=self.slice_count, lock=self.lock)
+        def _make_slice_request(self, dims: Dims) -> FakeSliceRequestError:
+            self._slice_request_count += 1
+            return FakeSliceRequestError(
+                id=self._slice_request_count, lock=self.lock
+            )
 
     layer = FakeAsyncLayerError()
-    future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+    future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     done, _ = wait([future], timeout=5)
     assert done, 'Test future did not complete within timeout.'
@@ -320,9 +316,7 @@ def test_wait_until_idle(layer_slicer, single_threaded_executor):
     layer = FakeAsyncLayer()
 
     with layer.lock:
-        slice_future = layer_slicer.slice_layers_async(
-            layers=[layer], dims=dims
-        )
+        slice_future = layer_slicer.submit(layers=[layer], dims=dims)
         _wait_until_running(slice_future)
         # The slice task has started, but has not finished yet
         # because we are holding the layer's slicing lock.
@@ -349,10 +343,10 @@ def test_layer_slicer_force_sync_on_sync_layer(layer_slicer):
 
     with layer_slicer.force_sync():
         assert layer_slicer._force_sync
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+        future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert future is None
     assert not layer_slicer._force_sync
 
 
@@ -361,13 +355,13 @@ def test_layer_slicer_force_sync_on_async_layer(layer_slicer):
 
     with layer_slicer.force_sync():
         assert layer_slicer._force_sync
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=Dims())
+        future = layer_slicer.submit(layers=[layer], dims=Dims())
 
     assert layer.slice_count == 1
-    assert future.result() == {}
+    assert future is None
 
 
-def test_slice_layers_async_with_one_3d_image(layer_slicer):
+def test_submit_with_one_3d_image(layer_slicer):
     np.random.seed(0)
     data = np.random.rand(8, 7, 6)
     lockable_data = LockableData(data)
@@ -380,14 +374,14 @@ def test_slice_layers_async_with_one_3d_image(layer_slicer):
     )
 
     with lockable_data.lock:
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        future = layer_slicer.submit(layers=[layer], dims=dims)
         assert not future.done()
 
     layer_result = future.result()[layer]
     np.testing.assert_equal(layer_result.data, data[2, :, :])
 
 
-def test_slice_layers_async_with_one_3d_points(layer_slicer):
+def test_submit_with_one_3d_points(layer_slicer):
     """ensure that async slicing of points does not block"""
     np.random.seed(0)
     num_points = 100
@@ -407,5 +401,13 @@ def test_slice_layers_async_with_one_3d_points(layer_slicer):
     )
 
     with lockable_internal_data.lock:
-        future = layer_slicer.slice_layers_async(layers=[layer], dims=dims)
+        future = layer_slicer.submit(layers=[layer], dims=dims)
         assert not future.done()
+
+
+def test_submit_after_shutdown_raises():
+    layer_slicer = _LayerSlicer()
+    layer_slicer._force_sync = False
+    layer_slicer.shutdown()
+    with pytest.raises(RuntimeError):
+        layer_slicer.submit(layers=[FakeAsyncLayer()], dims=Dims())

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -197,7 +197,7 @@ def test_submit_multiple_calls_cancels_pending(layer_slicer):
     assert pending.cancelled()
 
 
-def test_slice_layers_mixed_allows_sync_to_run(layer_slicer):
+def test_submit_mixed_allows_sync_to_run(layer_slicer):
     """ensure that a blocked async slice doesn't block sync slicing"""
     dims = Dims()
     layer1 = FakeAsyncLayer()
@@ -211,7 +211,7 @@ def test_slice_layers_mixed_allows_sync_to_run(layer_slicer):
     assert _wait_for_result(blocked)[layer1].id == 1
 
 
-def test_slice_layers_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
+def test_submit_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
     """ensure that a blocked async slice doesn't block sync slicing"""
     dims = Dims()
     layer1 = FakeAsyncLayer()
@@ -255,7 +255,7 @@ def test_submit_task_to_layers_lock(layer_slicer):
     assert task not in layer_slicer._layers_to_task
 
 
-def test_slice_layers_exception_main_thread(layer_slicer):
+def test_submit_exception_main_thread(layer_slicer):
     """Exception is raised on the main thread from an error on the main
     thread immediately when the task is created."""
 
@@ -268,7 +268,7 @@ def test_slice_layers_exception_main_thread(layer_slicer):
         layer_slicer.submit(layers=[layer], dims=Dims())
 
 
-def test_slice_layers_exception_subthread_on_result(layer_slicer):
+def test_submit_exception_subthread_on_result(layer_slicer):
     """Exception is raised on the main thread from an error on a subthread
     only after result is called, not upon submission of the task."""
 
@@ -317,7 +317,7 @@ def test_wait_until_idle(layer_slicer, single_threaded_executor):
     assert len(layer_slicer._layers_to_task) == 0
 
 
-def test_layer_slicer_force_sync_on_sync_layer(layer_slicer):
+def test_force_sync_on_sync_layer(layer_slicer):
     layer = FakeSyncLayer()
 
     with layer_slicer.force_sync():
@@ -329,7 +329,7 @@ def test_layer_slicer_force_sync_on_sync_layer(layer_slicer):
     assert not layer_slicer._force_sync
 
 
-def test_layer_slicer_force_sync_on_async_layer(layer_slicer):
+def test_force_sync_on_async_layer(layer_slicer):
     layer = FakeAsyncLayer()
 
     with layer_slicer.force_sync():

--- a/napari/layers/base/_slice.py
+++ b/napari/layers/base/_slice.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import Protocol
+
+from napari.layers.utils._slice_input import _SliceInput
+
+
+class Layer(Protocol):
+    _slice_input: _SliceInput
+
+    def set_view_slice(self) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class _LayerSliceResponse:
+    pass
+
+
+@dataclass(frozen=True)
+class _LayerSliceRequest:
+    layer: Layer
+    dims: _SliceInput
+
+    def supports_async(self) -> bool:
+        return False
+
+    def __call__(self) -> _LayerSliceResponse:
+        self.layer._slice_input = self.dims
+        self.layer.set_view_slice()

--- a/napari/layers/base/_slice.py
+++ b/napari/layers/base/_slice.py
@@ -21,6 +21,7 @@ class _LayerSliceRequest:
     layer: Layer
     dims: _SliceInput
 
+    @property
     def supports_async(self) -> bool:
         return False
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -964,10 +964,13 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     def _make_slice_request(
         self, dims: Dims, *, refresh_only: bool = False
     ) -> _LayerSliceRequest:
-        if refresh_only:
-            return _LayerSliceRequest(layer=self, dims=self._slice_input)
-        slice_input = self._make_slice_input(
-            dims.point, dims.ndisplay, dims.order
+        # TODO: consider always computing slice input since it should be cheap
+        # then using a force parameter, which when true always returns a request
+        # if they're the same.
+        slice_input = (
+            self._slice_input
+            if refresh_only
+            else self._make_slice_input(dims.point, dims.ndisplay, dims.order)
         )
         return _LayerSliceRequest(layer=self, dims=slice_input)
 

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -34,6 +34,7 @@ class _ImageSliceResponse:
         The slice indices in the layer's data space.
     """
 
+    request: '_ImageSliceRequest'
     data: Any = field(repr=False)
     thumbnail: Optional[Any] = field(repr=False)
     tile_to_data: Affine = field(repr=False)
@@ -82,6 +83,9 @@ class _ImageSliceRequest:
     downsample_factors: np.ndarray = field(repr=False)
     lazy: bool = field(default=False, repr=False)
 
+    def supports_async(self) -> bool:
+        return True
+
     def __call__(self) -> _ImageSliceResponse:
         with self.dask_indexer():
             return (
@@ -101,6 +105,7 @@ class _ImageSliceRequest:
             name='tile2data', linear_matrix=np.eye(ndim), ndim=ndim
         )
         return _ImageSliceResponse(
+            request=self,
             data=image,
             thumbnail=None,
             tile_to_data=tile_to_data,
@@ -157,6 +162,7 @@ class _ImageSliceRequest:
             thumbnail = np.asarray(thumbnail)
 
         return _ImageSliceResponse(
+            request=self,
             data=image,
             thumbnail=thumbnail,
             tile_to_data=tile_to_data,

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -83,6 +83,7 @@ class _ImageSliceRequest:
     downsample_factors: np.ndarray = field(repr=False)
     lazy: bool = field(default=False, repr=False)
 
+    @property
     def supports_async(self) -> bool:
         return True
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import types
 import warnings
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, List, Sequence, Tuple, Union
 
 import numpy as np
@@ -33,6 +34,7 @@ from napari.layers.utils._slice_input import _SliceInput
 from napari.layers.utils.layer_utils import calc_data_range
 from napari.layers.utils.plane import SlicingPlane
 from napari.utils import config
+from napari.utils._dask_utils import DaskIndexer
 from napari.utils._dtype import get_dtype_limits, normalize_dtype
 from napari.utils.colormaps import AVAILABLE_COLORMAPS
 from napari.utils.events import Event
@@ -764,28 +766,41 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         # The new slicing code makes a request from the existing state and
         # executes the request on the calling thread directly.
         # For async slicing, the calling thread will not be the main thread.
-        request = self._make_slice_request_internal(self._slice_input, indices)
+        request = self._make_slice_request_internal(
+            slice_input=self._slice_input,
+            indices=indices,
+            lazy=True,
+            dask_indexer=nullcontext,
+        )
         response = request()
-        self._update_slice_response(response, indices)
+        self._update_slice_response(response)
 
     def _make_slice_request(self, dims: Dims) -> _ImageSliceRequest:
         """Make an image slice request based on the given dims and this image."""
         slice_input = self._make_slice_input(
             dims.point, dims.ndisplay, dims.order
         )
-        # TODO: for the existing sync slicing, slice_indices is passed through
+        # TODO: for the existing sync slicing, indices is passed through
         # to avoid some performance issues related to the evaluation of the
         # data-to-world transform and its inverse. Async slicing currently
         # absorbs these performance issues here, but we can likely improve
         # things either by caching the world-to-data transform on the layer
         # or by lazily evaluating it in the slice task itself.
-        slice_indices = slice_input.data_indices(self._data_to_world.inverse)
-        return self._make_slice_request_internal(slice_input, slice_indices)
+        indices = slice_input.data_indices(self._data_to_world.inverse)
+        return self._make_slice_request_internal(
+            slice_input=slice_input,
+            indices=indices,
+            lazy=False,
+            dask_indexer=self.dask_optimized_slicing,
+        )
 
     def _make_slice_request_internal(
         self,
+        *,
         slice_input: _SliceInput,
-        slice_indices,
+        indices: Tuple[Union[int, slice], ...],
+        lazy: bool,
+        dask_indexer: DaskIndexer,
     ) -> _ImageSliceRequest:
         """Needed to support old-style sync slicing through _slice_dims and
         _set_view_slice.
@@ -796,7 +811,8 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         return _ImageSliceRequest(
             dims=slice_input,
             data=self.data,
-            slice_indices=slice_indices,
+            dask_indexer=dask_indexer,
+            indices=indices,
             multiscale=self.multiscale,
             corner_pixels=self.corner_pixels,
             rgb=self.rgb,
@@ -804,17 +820,18 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
             thumbnail_level=self._thumbnail_level,
             level_shapes=self.level_shapes,
             downsample_factors=self.downsample_factors,
-            lazy=True,
+            lazy=lazy,
         )
 
-    def _update_slice_response(
-        self, response: _ImageSliceResponse, indices
-    ) -> None:
+    def _update_slice_response(self, response: _ImageSliceResponse) -> None:
         """Update the slice output state currently on the layer."""
+        self._slice_input = response.dims
+
         # For the old experimental async code.
+        self._empty = False
         slice_data = self._SliceDataClass(
             layer=self,
-            indices=indices,
+            indices=response.indices,
             image=response.data,
             thumbnail_source=response.thumbnail,
         )

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -775,7 +775,9 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         response = request()
         self._update_slice_response(response)
 
-    def _make_slice_request(self, dims: Dims) -> _ImageSliceRequest:
+    def _make_slice_request(
+        self, dims: Dims, *, refresh_only: bool = False
+    ) -> _ImageSliceRequest:
         """Make an image slice request based on the given dims and this image."""
         slice_input = self._make_slice_input(
             dims.point, dims.ndisplay, dims.order

--- a/napari/layers/points/_slice.py
+++ b/napari/layers/points/_slice.py
@@ -57,6 +57,7 @@ class _PointSliceRequest:
     size: Any = field(repr=False)
     out_of_slice_display: bool = field(repr=False)
 
+    @property
     def supports_async(self) -> bool:
         return True
 

--- a/napari/layers/points/_slice.py
+++ b/napari/layers/points/_slice.py
@@ -57,6 +57,9 @@ class _PointSliceRequest:
     size: Any = field(repr=False)
     out_of_slice_display: bool = field(repr=False)
 
+    def supports_async(self) -> bool:
+        return True
+
     def __call__(self) -> _PointSliceResponse:
         # Return early if no data
         if len(self.data) == 0:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1695,7 +1695,7 @@ class Points(Layer):
             self._slice_input, self._slice_indices
         )
         response = request()
-        self._set_slice_response(response)
+        self._update_slice_response(response)
 
     def _make_slice_request(self, dims) -> _PointSliceRequest:
         """Make a Points slice request based on the given dims and these data."""
@@ -1723,8 +1723,9 @@ class Points(Layer):
             size=self.size,
         )
 
-    def _set_slice_response(self, response: _PointSliceResponse):
+    def _update_slice_response(self, response: _PointSliceResponse):
         """Handle a slicing response."""
+        self._slice_input = response.dims
         indices = response.indices
         scale = response.scale
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1697,7 +1697,9 @@ class Points(Layer):
         response = request()
         self._update_slice_response(response)
 
-    def _make_slice_request(self, dims) -> _PointSliceRequest:
+    def _make_slice_request(
+        self, dims, *, refresh_only: bool = False
+    ) -> _PointSliceRequest:
         """Make a Points slice request based on the given dims and these data."""
         slice_input = self._make_slice_input(
             dims.point, dims.ndisplay, dims.order

--- a/napari/utils/_dask_utils.py
+++ b/napari/utils/_dask_utils.py
@@ -15,6 +15,8 @@ from dask.cache import Cache
 _DASK_CACHE = Cache(1)
 _DEFAULT_MEM_FRACTION = 0.25
 
+DaskIndexer = Callable[[], ContextManager[Optional[Tuple[dict, Cache]]]]
+
 
 def resize_dask_cache(
     nbytes: Optional[int] = None, mem_fraction: Optional[float] = None
@@ -82,9 +84,7 @@ def _is_dask_data(data) -> bool:
     )
 
 
-def configure_dask(
-    data, cache=True
-) -> Callable[[], ContextManager[Optional[Tuple[dict, Cache]]]]:
+def configure_dask(data, cache=True) -> DaskIndexer:
     """Spin up cache and return context manager that optimizes Dask indexing.
 
     This function determines whether data is a dask array or list of dask

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -140,6 +140,8 @@ class Viewer(ViewerModel):
 
     def close(self):
         """Close the viewer window."""
+        # Shutdown the slicer first to avoid processing any more tasks.
+        self._layer_slicer.shutdown()
         # Remove all the layers from the viewer
         self.layers.clear()
         # Close the main window


### PR DESCRIPTION
A WIP alternative to https://github.com/napari/napari/pull/5377.

This approach makes the code in `LayerSlicer` more readable and also makes all slicing go through `QtViewer.on_slice_ready` regardless if they're async or sync.

But this comes at the expense of a bit more in/redirection in the Layers that don't support async yet.