### PR TITLE
add ui flag for async

### DIFF
--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -18,6 +18,7 @@ from typing import (
 from napari.components import Dims
 from napari.layers import Layer
 from napari.utils.events.event import EmitterGroup, Event
+from napari.settings import get_settings
 
 logger = logging.getLogger("napari.components._layer_slicer")
 
@@ -74,7 +75,7 @@ class _LayerSlicer:
         """
         self.events = EmitterGroup(source=self, ready=Event)
         self._executor: Executor = ThreadPoolExecutor(max_workers=1)
-        self._force_sync = True
+        self._force_sync = get_settings().experimental.async_slicing
         self._layers_to_task: Dict[Tuple[Layer], Future] = {}
         self._lock_layers_to_task = RLock()
 

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -75,7 +75,7 @@ class _LayerSlicer:
         """
         self.events = EmitterGroup(source=self, ready=Event)
         self._executor: Executor = ThreadPoolExecutor(max_workers=1)
-        self._force_sync = get_settings().experimental.async_slicing
+        self._force_sync = not get_settings().experimental.async_slicing
         self._layers_to_task: Dict[Tuple[Layer], Future] = {}
         self._lock_layers_to_task = RLock()
 

--- a/napari/settings/_experimental.py
+++ b/napari/settings/_experimental.py
@@ -34,6 +34,7 @@ class ExperimentalSettings(EventedSettings):
         description="",
         type='boolean',
         requires_restart=False,
+        env='napari_async_slicing',
     )
 
     class NapariConfig:

--- a/napari/settings/_experimental.py
+++ b/napari/settings/_experimental.py
@@ -28,6 +28,14 @@ class ExperimentalSettings(EventedSettings):
         requires_restart=True,
     )
 
+    async_slicing: bool = Field(
+        False,
+        title="Use asynchronous slicing",
+        description="",
+        type='boolean',
+        requires_restart=False,
+    )
+
     class NapariConfig:
         # Napari specific configuration
         preferences_exclude = ['schema_version']


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
We need a way for users to enable and disable the new async slicing mechanism. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->
Resolves https://github.com/napari/napari/issues/5517

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).

## Work to be done:
- [ ] Resolve widget relationships between old and new async (or remove old? see issue)
- [x] Add environment variable option. 
- [ ] Add tests
- [x] persistence between sessions
- [x] confirmed that this approach works for new instances of `_LayerSlicer`
