### PR TITLE
[WIP] Fix axes display labels

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -724,7 +724,6 @@ def _node_scene_size(node: Union[ImageVisual, VolumeVisual]) -> np.ndarray:
 def test_axes_labels(make_napari_viewer):
     viewer = make_napari_viewer(ndisplay=3)
     layer = viewer.add_image(np.zeros((2, 2, 2)), scale=(1, 2, 4))
-    viewer.dims.axis_labels = ('a', 'b', 'c')
 
     layer_visual = viewer._window._qt_viewer.layer_to_visual[layer]
     axes_visual = viewer._window._qt_viewer.overlay_to_visual[
@@ -733,4 +732,4 @@ def test_axes_labels(make_napari_viewer):
 
     layer_size = _node_scene_size(layer_visual.node)
     assert tuple(layer_size) == (8, 4, 2)
-    assert tuple(axes_visual.node.text.text) == ('c', 'b', 'a')
+    assert tuple(axes_visual.node.text.text) == ('2', '1', '0')

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -2,7 +2,7 @@ import gc
 import os
 import weakref
 from dataclasses import dataclass
-from typing import List
+from typing import List, Union
 from unittest import mock
 
 import numpy as np
@@ -10,6 +10,8 @@ import pytest
 from imageio import imread
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import QMessageBox
+from vispy.visuals import ImageVisual, VolumeVisual
+from vispy.visuals.transforms.linear import STTransform
 
 from napari._qt.qt_viewer import QtViewer
 from napari._tests.utils import (
@@ -696,3 +698,39 @@ def test_create_non_empty_viewer_model(qtbot):
     del viewer
     qtbot.wait(50)
     gc.collect()
+
+
+def _node_scene_size(node: Union[ImageVisual, VolumeVisual]) -> np.ndarray:
+    """Calculates the size of a vispy image/volume node in 3D space.
+
+    The size is the shape of the node's data multiplied by the
+    node's transform scale factors.
+
+    Returns
+    -------
+    np.ndarray
+        The size of the node as a 3-vector of the form (x, y, z).
+    """
+    data = node._last_data if isinstance(node, VolumeVisual) else node._data
+    # Only use scale to ignore translate offset used to center top-left pixel.
+    transform = STTransform(scale=np.diag(node.transform.matrix))
+    # Vispy uses an xy-style ordering, whereas numpy uses a rc-style
+    # ordering, so reverse the shape before applying the transform.
+    size = transform.map(data.shape[::-1])
+    # The last element should always be one, so ignore it.
+    return size[:3]
+
+
+def test_axes_labels(make_napari_viewer):
+    viewer = make_napari_viewer(ndisplay=3)
+    layer = viewer.add_image(np.zeros((2, 2, 2)), scale=(1, 2, 4))
+    viewer.dims.axis_labels = ('a', 'b', 'c')
+
+    layer_visual = viewer._window._qt_viewer.layer_to_visual[layer]
+    axes_visual = viewer._window._qt_viewer.overlay_to_visual[
+        viewer._overlays['axes']
+    ]
+
+    layer_size = _node_scene_size(layer_visual.node)
+    assert tuple(layer_size) == (8, 4, 2)
+    assert tuple(axes_visual.node.text.text) == ('c', 'b', 'a')

--- a/napari/_tests/utils.py
+++ b/napari/_tests/utils.py
@@ -6,8 +6,11 @@ from typing import Any, Dict
 import numpy as np
 import pandas as pd
 import pytest
+from vispy.visuals import VolumeVisual
+from vispy.visuals.transforms.linear import STTransform
 
 from napari import Viewer
+from napari._vispy.layers.image import VispyImageLayer
 from napari.layers import (
     Image,
     Labels,
@@ -287,3 +290,25 @@ def assert_colors_equal(actual, expected):
     actual_array = ColorArray.validate(actual)
     expected_array = ColorArray.validate(expected)
     np.testing.assert_array_equal(actual_array, expected_array)
+
+
+def vispy_image_scene_size(vispy_image: VispyImageLayer) -> np.ndarray:
+    """Calculates the size of a vispy image/volume in 3D space.
+
+    The size is the shape of the node's data multiplied by the
+    node's transform scale factors.
+
+    Returns
+    -------
+    np.ndarray
+        The size of the node as a 3-vector of the form (x, y, z).
+    """
+    node = vispy_image.node
+    data = node._last_data if isinstance(node, VolumeVisual) else node._data
+    # Only use scale to ignore translate offset used to center top-left pixel.
+    transform = STTransform(scale=np.diag(node.transform.matrix))
+    # Vispy uses an xy-style ordering, whereas numpy uses a rc-style
+    # ordering, so reverse the shape before applying the transform.
+    size = transform.map(data.shape[::-1])
+    # The last element should always be one, so ignore it.
+    return size[:3]

--- a/napari/_vispy/_tests/test_vispy_axes_overlay.py
+++ b/napari/_vispy/_tests/test_vispy_axes_overlay.py
@@ -1,0 +1,39 @@
+from napari._vispy.overlays.axes import VispyAxesOverlay
+from napari.components import ViewerModel
+from napari.components.overlays import AxesOverlay
+
+
+def test_init_with_2d_display_of_2_dimensions():
+    axes_model = AxesOverlay()
+    viewer = ViewerModel(axis_labels=('a', 'b'))
+    viewer.dims.ndim = 2
+    viewer.dims.ndisplay = 3
+
+    axes_view = VispyAxesOverlay(viewer=viewer, overlay=axes_model)
+
+    assert tuple(axes_view.node.text.text) == ('b', 'a')
+
+
+def test_init_with_2d_display_of_3_dimensions():
+    axes_model = AxesOverlay()
+    viewer = ViewerModel(axis_labels=('a', 'b', 'c'))
+    viewer.dims.ndim = 2
+    viewer.dims.ndisplay = 3
+
+    axes_view = VispyAxesOverlay(viewer=viewer, overlay=axes_model)
+
+    assert tuple(axes_view.node.text.text) == ('c', 'b')
+
+
+def test_init_with_3d_display_of_3_dimensions():
+    axes_model = AxesOverlay()
+    viewer = ViewerModel()
+    # TODO: passing through initializer replaces 'a' with '0', likely
+    # due to root validator, so set here instead.
+    viewer.dims.ndim = 3
+    viewer.dims.ndisplay = 3
+    viewer.dims.axis_labels = ('a', 'b', 'c')
+
+    axes_view = VispyAxesOverlay(viewer=viewer, overlay=axes_model)
+
+    assert tuple(axes_view.node.text.text) == ('c', 'b', 'a')

--- a/napari/_vispy/_tests/test_vispy_axes_overlay.py
+++ b/napari/_vispy/_tests/test_vispy_axes_overlay.py
@@ -5,35 +5,43 @@ from napari.components.overlays import AxesOverlay
 
 def test_init_with_2d_display_of_2_dimensions():
     axes_model = AxesOverlay()
-    viewer = ViewerModel(axis_labels=('a', 'b'))
+    viewer = ViewerModel()
     viewer.dims.ndim = 2
     viewer.dims.ndisplay = 3
 
     axes_view = VispyAxesOverlay(viewer=viewer, overlay=axes_model)
 
-    assert tuple(axes_view.node.text.text) == ('b', 'a')
+    assert tuple(axes_view.node.text.text) == ('1', '0')
 
 
 def test_init_with_2d_display_of_3_dimensions():
     axes_model = AxesOverlay()
-    viewer = ViewerModel(axis_labels=('a', 'b', 'c'))
+    viewer = ViewerModel()
+    viewer.dims.ndim = 3
+    viewer.dims.ndisplay = 2
+
+    axes_view = VispyAxesOverlay(viewer=viewer, overlay=axes_model)
+
+    assert tuple(axes_view.node.text.text) == ('2', '1')
+
+
+def test_init_with_3d_display_of_2_dimensions():
+    axes_model = AxesOverlay()
+    viewer = ViewerModel()
     viewer.dims.ndim = 2
     viewer.dims.ndisplay = 3
 
     axes_view = VispyAxesOverlay(viewer=viewer, overlay=axes_model)
 
-    assert tuple(axes_view.node.text.text) == ('c', 'b')
+    assert tuple(axes_view.node.text.text) == ('1', '0')
 
 
 def test_init_with_3d_display_of_3_dimensions():
     axes_model = AxesOverlay()
     viewer = ViewerModel()
-    # TODO: passing through initializer replaces 'a' with '0', likely
-    # due to root validator, so set here instead.
     viewer.dims.ndim = 3
     viewer.dims.ndisplay = 3
-    viewer.dims.axis_labels = ('a', 'b', 'c')
 
     axes_view = VispyAxesOverlay(viewer=viewer, overlay=axes_model)
 
-    assert tuple(axes_view.node.text.text) == ('c', 'b', 'a')
+    assert tuple(axes_view.node.text.text) == ('2', '1', '0')

--- a/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -1,45 +1,11 @@
 from itertools import permutations
-from typing import Union
 
 import numpy as np
 import pytest
-from vispy.visuals import ImageVisual, VolumeVisual
-from vispy.visuals.transforms.linear import STTransform
 
+from napari._tests.utils import vispy_image_scene_size
 from napari._vispy.layers.image import VispyImageLayer
 from napari.layers import Image
-
-
-def _node_scene_size(node: Union[ImageVisual, VolumeVisual]) -> np.ndarray:
-    """Calculates the size of a vispy image/volume node in 3D space.
-
-    The size is the shape of the node's data multiplied by the
-    node's transform scale factors.
-
-    Returns
-    -------
-    np.ndarray
-        The size of the node as a 3-vector of the form (x, y, z).
-    """
-    data = node._last_data if isinstance(node, VolumeVisual) else node._data
-    # Only use scale to ignore translate offset used to center top-left pixel.
-    transform = STTransform(scale=np.diag(node.transform.matrix))
-    # Vispy uses an xy-style ordering, whereas numpy uses a rc-style
-    # ordering, so reverse the shape before applying the transform.
-    size = transform.map(data.shape[::-1])
-    # The last element should always be one, so ignore it.
-    return size[:3]
-
-
-def test_3d_slice_of_3d_image():
-    """See https://github.com/napari/napari/issues/5536"""
-    image = Image(np.zeros((2, 2, 2)), scale=(1, 2, 4))
-    vispy_image = VispyImageLayer(image)
-
-    image._slice_dims(point=(0, 0, 0), ndisplay=3)
-
-    scene_size = _node_scene_size(vispy_image.node)
-    np.testing.assert_array_equal((8, 4, 2), scene_size)
 
 
 @pytest.mark.parametrize('order', permutations((0, 1, 2)))
@@ -54,7 +20,7 @@ def test_3d_slice_of_2d_image_with_order(order):
 
     image._slice_dims(point=(0, 0, 0), ndisplay=3, order=order)
 
-    scene_size = _node_scene_size(vispy_image.node)
+    scene_size = vispy_image_scene_size(vispy_image)
     np.testing.assert_array_equal((4, 4, 1), scene_size)
 
 
@@ -70,7 +36,7 @@ def test_2d_slice_of_3d_image_with_order(order):
 
     image._slice_dims(point=(0, 0, 0), ndisplay=2, order=order)
 
-    scene_size = _node_scene_size(vispy_image.node)
+    scene_size = vispy_image_scene_size(vispy_image)
     np.testing.assert_array_equal((8, 8, 0), scene_size)
 
 
@@ -86,7 +52,7 @@ def test_3d_slice_of_3d_image_with_order(order):
 
     image._slice_dims(point=(0, 0, 0), ndisplay=3, order=order)
 
-    scene_size = _node_scene_size(vispy_image.node)
+    scene_size = vispy_image_scene_size(vispy_image)
     np.testing.assert_array_equal((8, 8, 8), scene_size)
 
 
@@ -102,5 +68,5 @@ def test_3d_slice_of_4d_image_with_order(order):
 
     image._slice_dims(point=(0, 0, 0, 0), ndisplay=3, order=order)
 
-    scene_size = _node_scene_size(vispy_image.node)
+    scene_size = vispy_image_scene_size(vispy_image)
     np.testing.assert_array_equal((16, 16, 16), scene_size)

--- a/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -31,6 +31,17 @@ def _node_scene_size(node: Union[ImageVisual, VolumeVisual]) -> np.ndarray:
     return size[:3]
 
 
+def test_3d_slice_of_3d_image():
+    """See https://github.com/napari/napari/issues/5536"""
+    image = Image(np.zeros((2, 2, 2)), scale=(1, 2, 4))
+    vispy_image = VispyImageLayer(image)
+
+    image._slice_dims(point=(0, 0, 0), ndisplay=3)
+
+    scene_size = _node_scene_size(vispy_image.node)
+    np.testing.assert_array_equal((8, 4, 2), scene_size)
+
+
 @pytest.mark.parametrize('order', permutations((0, 1, 2)))
 def test_3d_slice_of_2d_image_with_order(order):
     """See https://github.com/napari/napari/issues/4926

--- a/napari/_vispy/overlays/axes.py
+++ b/napari/_vispy/overlays/axes.py
@@ -17,7 +17,6 @@ class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):
         super().__init__(
             node=Axes(), viewer=viewer, overlay=overlay, parent=parent
         )
-        self.overlay.events.visible.connect(self._on_visible_change)
         self.overlay.events.colored.connect(self._on_data_change)
         self.overlay.events.dashed.connect(self._on_data_change)
         self.overlay.events.labels.connect(self._on_labels_visible_change)
@@ -51,6 +50,8 @@ class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):
             dashed=self.overlay.dashed,
             arrows=self.overlay.arrows,
         )
+
+        self._on_labels_text_change()
 
     def _on_labels_visible_change(self):
         self.node.text.visible = self.overlay.labels


### PR DESCRIPTION
This is a work in progress that currently defines some tests that should pass. Most of them do, except `napari/_vispy/_tests/test_vispy_image_layer.py::test_axes_labels`, which requires a full viewer as in the example given in #5536.

Closes #5536.