### PR TITLE
Fix feature defaults without setter

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from vispy.color import get_colormap
 
 from napari._tests.utils import (
+    assert_colors_equal,
     assert_layer_state_equal,
     check_layer_world_data_extent,
 )
@@ -44,6 +45,40 @@ def _make_cycled_properties(values, length):
 def test_empty_points():
     pts = Points()
     assert pts.data.shape == (0, 2)
+
+
+def test_empty_points_with_features():
+    pts = Points(
+        features={'a': np.empty(0, int)},
+        face_color_cycle=list('rgb'),
+    )
+    pts.feature_defaults['a'] = 0
+    pts.face_color = 'a'
+
+    pts.add([0, 0])
+    pts.feature_defaults['a'] = 1
+    pts.add([50, 50])
+    pts.feature_defaults['a'] = 2
+    pts.add([100, 100])
+
+    assert_colors_equal(pts.face_color, list('rgb'))
+
+
+def test_empty_points_with_features_alt():
+    pts = Points(
+        features={'a': np.empty(0, int)},
+        face_color='a',
+        face_color_cycle=list('rgb'),
+    )
+
+    pts.feature_defaults['a'] = 0
+    pts.add([0, 0])
+    pts.feature_defaults['a'] = 1
+    pts.add([50, 50])
+    pts.feature_defaults['a'] = 2
+    pts.add([100, 100])
+
+    assert_colors_equal(pts.face_color, list('rgb'))
 
 
 def test_empty_points_with_properties():

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -471,7 +471,9 @@ class Points(Layer):
         self._status = self.mode
 
         color_properties = (
-            self.properties if self._data.size > 0 else self.property_choices
+            self._feature_table.properties()
+            if self._data.size > 0
+            else self._feature_table.currents()
         )
         self._edge = ColorManager._from_layer_kwargs(
             n_colors=len(data),
@@ -567,8 +569,13 @@ class Points(Layer):
                     new_symbol = self.current_symbol
                 symbol = np.repeat([new_symbol], adding, axis=0)
 
-                # add new colors
+                # Add new colors, updating the current property value before
+                # to handle any in-place modification of feature_defaults.
+                # Also see: https://github.com/napari/napari/issues/5634
+                current_properties = self._feature_table.currents()
+                self._edge._update_current_properties(current_properties)
                 self._edge._add(n_colors=adding)
+                self._face._update_current_properties(current_properties)
                 self._face._add(n_colors=adding)
 
                 shown = np.repeat([True], adding, axis=0)

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -890,6 +890,11 @@ def _get_default_column(column: pd.Series) -> pd.Series:
         choices = column.dtype.categories
         if choices.size > 0:
             value = choices[0]
+    # Series initializer with no data and int dtype will cause
+    # the dtype to become a float with a NaN as the data, so
+    # handle this special case.
+    if value is None and np.issubdtype(column.dtype, np.integer):
+        value = 0
     return pd.Series(data=value, dtype=column.dtype, index=range(1))
 
 


### PR DESCRIPTION
An alternative to https://github.com/napari/napari/pull/5646 that doesn't introduce a `feature_defaults` init parameter or setter.