### PR TITLE
Define base request and use for forced sync

### DIFF
--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -106,7 +106,7 @@ class _LayerSlicer:
         *,
         layers: Iterable[Layer],
         dims: Dims,
-        force: bool = False,
+        force: bool = True,
     ) -> Optional[Future[dict]]:
         """Slices the given layers with the given dims.
 
@@ -154,12 +154,12 @@ class _LayerSlicer:
         async_requests = {}
         sync_requests = {}
         for layer in [layer for layer in layers if layer.visible]:
-            request = layer._make_slice_request(dims)
-            if request.supports_async and not self._force_sync:
-                async_requests[layer] = request
-                layer._set_unloaded_slice_id(request.id)
-            else:
-                sync_requests[layer] = request
+            if request := layer._make_slice_request(dims, force=force):
+                if request.supports_async and not self._force_sync:
+                    async_requests[layer] = request
+                    layer._set_unloaded_slice_id(request.id)
+                else:
+                    sync_requests[layer] = request
 
         # First maybe submit an async slicing task to start it ASAP.
         async_task = None

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -2,7 +2,7 @@ import time
 from concurrent.futures import Future, wait
 from dataclasses import dataclass
 from threading import RLock, current_thread, main_thread
-from typing import Any
+from typing import Any, Dict
 
 import numpy as np
 import pytest
@@ -10,59 +10,26 @@ import pytest
 from napari._tests.utils import DEFAULT_TIMEOUT_SECS, LockableData
 from napari.components import Dims
 from napari.components._layer_slicer import _LayerSlicer
-from napari.layers import Image, Points
-
-# The following fakes are used to control execution of slicing across
-# multiple threads, while also allowing us to mimic real classes
-# (like layers) in the code base. This allows us to assert state and
-# conditions that may only be temporarily true at different stages of
-# an asynchronous task.
+from napari.layers import Image, Layer, Points, Shapes
+from napari.layers.base._slice import _SliceRequest, _SliceResponse
 
 
-@dataclass(frozen=True)
-class FakeSliceResponse:
-    id: int
+class SliceObserver:
+    """Used to observe the ready event from the layer slicer."""
 
+    def __init__(self):
+        self._last_response: Dict[Layer, _SliceResponse] = {}
+        self._lock = RLock()
 
-@dataclass(frozen=True)
-class FakeSliceRequest:
-    id: int
-    lock: RLock
+    def on_slice_ready(self, event) -> None:
+        responses = event.value
+        with self._lock:
+            for layer, response in responses.items():
+                self._last_response[layer] = response
 
-    def __call__(self) -> FakeSliceResponse:
-        assert current_thread() != main_thread()
-        with self.lock:
-            return FakeSliceResponse(id=self.id)
-
-
-class FakeAsyncLayer:
-    def __init__(self) -> None:
-        self._last_slice_id: int = 0
-        self._slice_request_count: int = 0
-        self.slice_count: int = 0
-        self.lock: RLock = RLock()
-
-    def _make_slice_request(self, dims: Dims) -> FakeSliceRequest:
-        assert current_thread() == main_thread()
-        self._slice_request_count += 1
-        return FakeSliceRequest(id=self._slice_request_count, lock=self.lock)
-
-    def _update_slice_response(self, response: FakeSliceResponse):
-        self.slice_count = response.id
-
-    def _slice_dims(self, *args, **kwargs) -> None:
-        self.slice_count += 1
-
-    def _set_unloaded_slice_id(self, slice_id: int) -> None:
-        self._last_slice_id = slice_id
-
-
-class FakeSyncLayer:
-    def __init__(self) -> None:
-        self.slice_count: int = 0
-
-    def _slice_dims(self, *args, **kwargs) -> None:
-        self.slice_count += 1
+    def get(self, layer: Layer) -> _SliceResponse:
+        with self._lock:
+            return self._last_response.get(layer)
 
 
 @pytest.fixture()
@@ -73,94 +40,96 @@ def layer_slicer():
     layer_slicer.shutdown()
 
 
-def test_submit_with_one_async_layer_no_block(layer_slicer):
-    layer = FakeAsyncLayer()
+@pytest.fixture()
+def slice_observer(layer_slicer: _LayerSlicer):
+    slice_observer = SliceObserver()
+    layer_slicer.events.ready.connect(slice_observer.on_slice_ready)
+    return slice_observer
+
+
+def make_lockable_image() -> Image:
+    np.random.seed(0)
+    data = np.random.rand(3, 2)
+    lockable_data = LockableData(data)
+    return Image(data=lockable_data, multiscale=False, rgb=False)
+
+
+def make_shapes() -> Shapes:
+    np.random.seed(0)
+    data = np.random.rand(3, 4, 2)
+    return Shapes(data)
+
+
+def test_submit_with_one_async_layer_no_block(layer_slicer, slice_observer):
+    layer = make_lockable_image()
 
     future = layer_slicer.submit(layers=[layer], dims=Dims())
 
-    assert _wait_for_result(future)[layer].id == 1
-    assert _wait_for_result(future)[layer].id == 1
+    result = _wait_for_result(future)
+    assert result[layer] is slice_observer.get(layer)
 
 
-def test_submit_with_multiple_async_layer_no_block(layer_slicer):
-    layer1 = FakeAsyncLayer()
-    layer2 = FakeAsyncLayer()
+def test_submit_with_multiple_async_layer_no_block(
+    layer_slicer, slice_observer
+):
+    layer1 = make_lockable_image()
+    layer2 = make_lockable_image()
 
     future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
-    assert _wait_for_result(future)[layer1].id == 1
-    assert _wait_for_result(future)[layer2].id == 1
+    result = _wait_for_result(future)
+    assert result[layer1] is slice_observer.get(layer1)
+    assert result[layer2] is slice_observer.get(layer2)
 
 
-def test_submit_emits_ready_event_when_done(layer_slicer):
-    layer = FakeAsyncLayer()
-    event_result = None
-
-    def on_done(event):
-        nonlocal event_result
-        event_result = event.value
-
-    layer_slicer.events.ready.connect(on_done)
-
-    future = layer_slicer.submit(layers=[layer], dims=Dims())
-    actual_result = _wait_for_result(future)
-
-    assert actual_result is event_result
-
-
-def test_submit_with_one_sync_layer(layer_slicer):
-    layer = FakeSyncLayer()
-    assert layer.slice_count == 0
+def test_submit_with_one_sync_layer(layer_slicer, slice_observer):
+    layer = make_shapes()
 
     future = layer_slicer.submit(layers=[layer], dims=Dims())
 
-    assert layer.slice_count == 1
     assert future is None
+    assert slice_observer.get(layer) is not None
 
 
-def test_submit_with_multiple_sync_layer(layer_slicer):
-    layer1 = FakeSyncLayer()
-    layer2 = FakeSyncLayer()
-    assert layer1.slice_count == 0
-    assert layer2.slice_count == 0
+def test_submit_with_multiple_sync_layer(layer_slicer, slice_observer):
+    layer1 = make_shapes()
+    layer2 = make_shapes()
 
     future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
-    assert layer1.slice_count == 1
-    assert layer2.slice_count == 1
     assert future is None
+    assert slice_observer.get(layer1) is not None
+    assert slice_observer.get(layer2) is not None
 
 
-def test_submit_with_mixed_layers(layer_slicer):
-    layer1 = FakeAsyncLayer()
-    layer2 = FakeSyncLayer()
-    assert layer1.slice_count == 0
-    assert layer2.slice_count == 0
+def test_submit_with_mixed_layers(layer_slicer, slice_observer):
+    layer1 = make_lockable_image()
+    layer2 = make_shapes()
 
     future = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
 
-    assert layer2.slice_count == 1
-    assert _wait_for_result(future)[layer1].id == 1
-    assert layer2 not in _wait_for_result(future)
+    result = _wait_for_result(future)
+    assert slice_observer.get(layer1) is result[layer1]
+    assert layer2 not in result
+    assert slice_observer.get(layer2) is not None
 
 
-def test_submit_lock_blocking(layer_slicer):
-    dims = Dims()
-    layer = FakeAsyncLayer()
+def test_submit_lock_blocking(layer_slicer, slice_observer):
+    layer = make_lockable_image()
 
-    assert layer.slice_count == 0
-    with layer.lock:
-        blocked = layer_slicer.submit(layers=[layer], dims=dims)
+    with layer.data.lock:
+        blocked = layer_slicer.submit(layers=[layer], dims=Dims())
         assert not blocked.done()
 
-    assert _wait_for_result(blocked)[layer].id == 1
+    result = _wait_for_result(blocked)
+    assert slice_observer.get(layer) is result[layer]
 
 
 def test_submit_multiple_calls_cancels_pending(layer_slicer):
     dims = Dims()
-    layer = FakeAsyncLayer()
+    layer = make_lockable_image()
 
-    with layer.lock:
+    with layer.data.lock:
         blocked = layer_slicer.submit(layers=[layer], dims=dims)
         _wait_until_running(blocked)
         pending = layer_slicer.submit(layers=[layer], dims=dims)
@@ -171,73 +140,70 @@ def test_submit_multiple_calls_cancels_pending(layer_slicer):
     assert pending.cancelled()
 
 
-def test_submit_mixed_allows_sync_to_run(layer_slicer):
+def test_submit_mixed_allows_sync_to_run(layer_slicer, slice_observer):
     """ensure that a blocked async slice doesn't block sync slicing"""
     dims = Dims()
-    layer1 = FakeAsyncLayer()
-    layer2 = FakeSyncLayer()
-    with layer1.lock:
+    layer1 = make_lockable_image()
+    layer2 = make_shapes()
+    with layer1.data.lock:
         blocked = layer_slicer.submit(layers=[layer1], dims=dims)
         layer_slicer.submit(layers=[layer2], dims=dims)
-        assert layer2.slice_count == 1
+        assert slice_observer.get(layer2) is not None
         assert not blocked.done()
 
-    assert _wait_for_result(blocked)[layer1].id == 1
+    result = _wait_for_result(blocked)
+    assert slice_observer.get(layer1) is result[layer1]
 
 
-def test_submit_mixed_allows_sync_to_run_one_slicer_call(layer_slicer):
+def test_submit_mixed_allows_sync_to_run_one_slicer_call(
+    layer_slicer, slice_observer
+):
     """ensure that a blocked async slice doesn't block sync slicing"""
     dims = Dims()
-    layer1 = FakeAsyncLayer()
-    layer2 = FakeSyncLayer()
-    with layer1.lock:
+    layer1 = make_lockable_image()
+    layer2 = make_shapes()
+    with layer1.data.lock:
         blocked = layer_slicer.submit(layers=[layer1, layer2], dims=dims)
-
-        assert layer2.slice_count == 1
+        sync_slice_1 = slice_observer.get(layer2)
+        assert sync_slice_1 is not None
+        layer_slicer.submit(layers=[layer2], dims=dims)
+        sync_slice_2 = slice_observer.get(layer2)
+        assert sync_slice_2 is not None
+        assert sync_slice_2 is not sync_slice_1
         assert not blocked.done()
 
-    assert _wait_for_result(blocked)[layer1].id == 1
+    result = _wait_for_result(blocked)
+    assert slice_observer.get(layer1) is result[layer1]
 
 
 def test_submit_with_multiple_async_layer_with_all_locked(
     layer_slicer,
+    slice_observer,
 ):
     """ensure that if only all layers are locked, none continue"""
-    dims = Dims()
-    layer1 = FakeAsyncLayer()
-    layer2 = FakeAsyncLayer()
+    layer1 = make_lockable_image()
+    layer2 = make_lockable_image()
 
-    with layer1.lock, layer2.lock:
-        blocked = layer_slicer.submit(layers=[layer1, layer2], dims=dims)
+    with layer1.data.lock, layer2.data.lock:
+        blocked = layer_slicer.submit(layers=[layer1, layer2], dims=Dims())
         assert not blocked.done()
+        assert slice_observer.get(layer1) is None
+        assert slice_observer.get(layer2) is None
 
-    assert _wait_for_result(blocked)[layer1].id == 1
-    assert _wait_for_result(blocked)[layer2].id == 1
-
-
-def test_submit_task_to_layers_lock(layer_slicer):
-    """ensure that if only one layer has a lock, the non-locked layer
-    can continue"""
-    dims = Dims()
-    layer = FakeAsyncLayer()
-
-    with layer.lock:
-        task = layer_slicer.submit(layers=[layer], dims=dims)
-        assert task in layer_slicer._layers_to_task.values()
-
-    assert _wait_for_result(task)[layer].id == 1
-    assert task not in layer_slicer._layers_to_task
+    result = _wait_for_result(blocked)
+    assert slice_observer.get(layer1) is result[layer1]
+    assert slice_observer.get(layer2) is result[layer2]
 
 
 def test_submit_exception_main_thread(layer_slicer):
     """Exception is raised on the main thread from an error on the main
     thread immediately when the task is created."""
 
-    class FakeAsyncLayerError(FakeAsyncLayer):
-        def _make_slice_request(self, dims) -> FakeSliceRequest:
+    class ErrorOnRequest(Image):
+        def _make_slice_request(self, dims: Dims) -> _SliceRequest:
             raise RuntimeError('_make_slice_request')
 
-    layer = FakeAsyncLayerError()
+    layer = ErrorOnRequest(np.zeros((3, 2)))
     with pytest.raises(RuntimeError, match='_make_slice_request'):
         layer_slicer.submit(layers=[layer], dims=Dims())
 
@@ -247,21 +213,25 @@ def test_submit_exception_subthread_on_result(layer_slicer):
     only after result is called, not upon submission of the task."""
 
     @dataclass(frozen=True)
-    class FakeSliceRequestError(FakeSliceRequest):
-        def __call__(self) -> FakeSliceResponse:
+    class ErroringSliceRequest:
+        id: int
+
+        def supports_async() -> bool:
+            return True
+
+        def __call__(self) -> _SliceResponse:
             assert current_thread() != main_thread()
             raise RuntimeError('FakeSliceRequestError')
 
-    class FakeAsyncLayerError(FakeAsyncLayer):
-        def _make_slice_request(self, dims: Dims) -> FakeSliceRequestError:
-            self._slice_request_count += 1
-            return FakeSliceRequestError(
-                id=self._slice_request_count, lock=self.lock
-            )
+    class ErrorOnSlice(Image):
+        def _make_slice_request(self, dims: Dims) -> ErroringSliceRequest:
+            return ErroringSliceRequest(id=0)
 
-    layer = FakeAsyncLayerError()
+    layer = ErrorOnSlice(np.zeros((3, 2)))
     future = layer_slicer.submit(layers=[layer], dims=Dims())
 
+    # First wait for the future to be done without triggering the
+    # exception, then get the result to trigger it.
     done, _ = wait([future], timeout=DEFAULT_TIMEOUT_SECS)
     assert done, 'Test future did not complete within timeout.'
     with pytest.raises(RuntimeError, match='FakeSliceRequestError'):
@@ -270,9 +240,9 @@ def test_submit_exception_subthread_on_result(layer_slicer):
 
 def test_wait_until_idle(layer_slicer, single_threaded_executor):
     dims = Dims()
-    layer = FakeAsyncLayer()
+    layer = make_lockable_image()
 
-    with layer.lock:
+    with layer.data.lock:
         slice_future = layer_slicer.submit(layers=[layer], dims=dims)
         _wait_until_running(slice_future)
         # The slice task has started, but has not finished yet
@@ -291,27 +261,28 @@ def test_wait_until_idle(layer_slicer, single_threaded_executor):
     assert len(layer_slicer._layers_to_task) == 0
 
 
-def test_force_sync_on_sync_layer(layer_slicer):
-    layer = FakeSyncLayer()
+def test_force_sync_on_sync_layer(layer_slicer, slice_observer):
+    layer = make_shapes()
 
     with layer_slicer.force_sync():
         assert layer_slicer._force_sync
         future = layer_slicer.submit(layers=[layer], dims=Dims())
 
-    assert layer.slice_count == 1
     assert future is None
+    assert slice_observer.get(layer) is not None
     assert not layer_slicer._force_sync
 
 
-def test_force_sync_on_async_layer(layer_slicer):
-    layer = FakeAsyncLayer()
+def test_force_sync_on_async_layer(layer_slicer, slice_observer):
+    layer = make_lockable_image()
 
     with layer_slicer.force_sync():
         assert layer_slicer._force_sync
         future = layer_slicer.submit(layers=[layer], dims=Dims())
 
-    assert layer.slice_count == 1
     assert future is None
+    assert slice_observer.get(layer) is not None
+    assert not layer_slicer._force_sync
 
 
 def test_submit_with_one_3d_image(layer_slicer):
@@ -336,7 +307,7 @@ def test_submit_with_one_3d_image(layer_slicer):
 def test_submit_with_one_3d_points(layer_slicer):
     """ensure that async slicing of points does not block"""
     np.random.seed(0)
-    num_points = 100
+    num_points = 2
     data = np.rint(2.0 * np.random.rand(num_points, 3))
     layer = Points(data=data)
 
@@ -362,7 +333,7 @@ def test_submit_after_shutdown_raises():
     layer_slicer._force_sync = False
     layer_slicer.shutdown()
     with pytest.raises(RuntimeError):
-        layer_slicer.submit(layers=[FakeAsyncLayer()], dims=Dims())
+        layer_slicer.submit(layers=[make_lockable_image()], dims=Dims())
 
 
 def _wait_until_running(future: Future):

--- a/napari/components/_tests/test_layer_slicer.py
+++ b/napari/components/_tests/test_layer_slicer.py
@@ -200,7 +200,7 @@ def test_submit_exception_main_thread(layer_slicer):
     thread immediately when the task is created."""
 
     class ErrorOnRequest(Image):
-        def _make_slice_request(self, dims: Dims) -> _SliceRequest:
+        def _make_slice_request(self, *args, **kwargs) -> _SliceRequest:
             raise RuntimeError('_make_slice_request')
 
     layer = ErrorOnRequest(np.zeros((3, 2)))
@@ -224,7 +224,7 @@ def test_submit_exception_subthread_on_result(layer_slicer):
             raise RuntimeError('FakeSliceRequestError')
 
     class ErrorOnSlice(Image):
-        def _make_slice_request(self, dims: Dims) -> ErroringSliceRequest:
+        def _make_slice_request(self, *args, **kwargs) -> ErroringSliceRequest:
             return ErroringSliceRequest(id=0)
 
     layer = ErrorOnSlice(np.zeros((3, 2)))

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -413,7 +413,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     def _on_layer_reload(self, event: Event) -> None:
         self._layer_slicer.submit(
-            layers=[event.layer], dims=self.dims, force=True
+            layers=[event.layer],
+            dims=self.dims,
+            force=True,
         )
 
     def _update_layers(self, *, layers=None):
@@ -425,7 +427,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             List of layers to update. If none provided updates all.
         """
         layers = layers or self.layers
-        self._layer_slicer.submit(layers=layers, dims=self.dims)
+        self._layer_slicer.submit(layers=layers, dims=self.dims, force=False)
         # If the currently selected layer is sliced asynchronously, then the value
         # shown with this position may be incorrect. See the discussion for more details:
         # https://github.com/napari/napari/pull/5377#discussion_r1036280855

--- a/napari/layers/base/_slice.py
+++ b/napari/layers/base/_slice.py
@@ -1,4 +1,11 @@
+from dataclasses import dataclass, field
 from itertools import count
+from typing import TYPE_CHECKING, Protocol
+
+from napari.layers.utils._slice_input import _SliceInput
+
+if TYPE_CHECKING:
+    from napari.layers import Layer
 
 # We use an incrementing non-negative integer to uniquely identify
 # slices that is unbounded based on Python 3's int.
@@ -8,3 +15,76 @@ _request_ids = count()
 def _next_request_id() -> int:
     """Returns the next integer identifier associated with a slice."""
     return next(_request_ids)
+
+
+class _SliceResponse(Protocol):
+    """Captures the output of slicing.
+
+    The attributes of this vary per layer type due to different data structures,
+    but some basic attributes are shared across all layers.
+
+    Attributes
+    ----------
+    request_id : int
+        The unique identifier associated with the request that generated this.
+    dims : _SliceInput
+        Describes the slicing plane or bounding box in the layer's dimensions.
+    """
+
+    request_id: int
+    dims: _SliceInput
+
+
+class _SliceRequest(Protocol):
+    """Callable that captures all state needed to slice a layer.
+
+    The attributes of this vary per layer type due to different data structures,
+    but some basic attributes are shared across all layers.
+
+    Attributes
+    ----------
+    id : int
+        The unique identifier associated with this request.
+        This is unique across all layer types for the liftime of a process.
+    dims : _SliceInput
+        Describes the slicing plane or bounding box in the layer's dimensions.
+    """
+
+    id: int
+    dims: _SliceInput
+
+    def supports_async(self) -> bool:
+        """Returns True if this can be safely called on a separate thread."""
+
+    def __call__(self) -> _SliceResponse:
+        """Executes this request to return a slice response."""
+
+
+@dataclass(frozen=True)
+class _LayerSliceResponse:
+    """The base layer slice response that only contains basic attributes.
+
+    A request that generates this response is expected to use the old approach
+    to slicing using `Layer.set_view_slice` to update the layer's slice state
+    through side-effects on the main thread.
+    """
+
+    request_id: int
+    dims: _SliceInput
+
+
+@dataclass(frozen=True)
+class _LayerSliceRequest:
+    """The base layer slice request that should only be executed on the main thread."""
+
+    layer: 'Layer'
+    dims: _SliceInput
+    id: int = field(default_factory=_next_request_id)
+
+    @property
+    def supports_async(self) -> bool:
+        return False
+
+    def __call__(self) -> _LayerSliceResponse:
+        self.layer.set_view_slice()
+        return _LayerSliceResponse(request_id=self.id, dims=self.dims)

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -174,6 +174,10 @@ class _ImageSliceRequest:
     downsample_factors: np.ndarray = field(repr=False)
     id: int = field(default_factory=_next_request_id)
 
+    @property
+    def supports_async(self) -> bool:
+        return True
+
     def __call__(self) -> _ImageSliceResponse:
         with self.dask_indexer():
             return (
@@ -184,7 +188,8 @@ class _ImageSliceRequest:
 
     def _call_single_scale(self) -> _ImageSliceResponse:
         order = self._get_order()
-        data = np.asarray(self.data[self.indices])
+        data = self.data[self.indices]
+        data = np.asarray(data)
         data = np.transpose(data, order)
         image = _ImageView.from_view(data)
         # `Layer.multiscale` is mutable so we need to pass back the identity

--- a/napari/layers/points/_slice.py
+++ b/napari/layers/points/_slice.py
@@ -62,6 +62,10 @@ class _PointSliceRequest:
     out_of_slice_display: bool = field(repr=False)
     id: int = field(default_factory=_next_request_id)
 
+    @property
+    def supports_async(self) -> bool:
+        return True
+
     def __call__(self) -> _PointSliceResponse:
         # Return early if no data
         if len(self.data) == 0:

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 from weakref import WeakSet
 
 import magicgui as mgui
+from superqt import ensure_main_thread
 
 from napari.components.viewer_model import ViewerModel
 from napari.utils import _magicgui
@@ -171,6 +172,15 @@ class Viewer(ViewerModel):
         for viewer in viewers:
             viewer.close()
         return ret
+
+    @ensure_main_thread
+    def _on_slice_ready(self, event):
+        """Callback connected to `viewer._layer_slicer.events.ready`.
+
+        Provides updates after slicing using the slice response data.
+        This only gets triggered on the async slicing path.
+        """
+        super()._on_slice_ready(event)
 
 
 def current_viewer() -> Optional[Viewer]:


### PR DESCRIPTION
This is one approach to using the same code for slicing when the async experimental flag is one.

A positive here is that the logic of `LayerSlicer.submit` is simpler. The sync and async requests are identical (and only differ by which thread they run on), rather than relying on `Layer._slice_dims` for sync slicing.

A negative here is that this force us to decide how much we care about layer slice state when we just have a `ViewerModel`. The solution here is to let the updates occur on the slicing thread and only force the main thread when we have a `Viewer` instead.