### PR TITLE
Make refresh async when experimental setting is on

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -383,7 +383,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             help=Event,
             interactive=WarningEmitter(
                 trans._(
-                    "layer.events.interactive is deprecated since 0.5.0 and will be removed in 0.6.0. Please use layer.events.mouse_pan and layer.events.mouse_zoom",
+                    "layer.events.interactive is deprecated since 0.4.18 and will be removed in 0.6.0. Please use layer.events.mouse_pan and layer.events.mouse_zoom",
                     deferred=True,
                 ),
                 type_name='interactive',
@@ -983,7 +983,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     def interactive(self) -> bool:
         warnings.warn(
             trans._(
-                "Layer.interactive is deprecated since napari 0.5.0 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead"
+                "Layer.interactive is deprecated since napari 0.4.18 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead"
             ),
             FutureWarning,
             stacklevel=2,
@@ -994,7 +994,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     def interactive(self, interactive: bool):
         warnings.warn(
             trans._(
-                "Layer.interactive is deprecated since napari 0.5.0 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead"
+                "Layer.interactive is deprecated since napari 0.4.18 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead"
             ),
             FutureWarning,
             stacklevel=2,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -836,8 +836,8 @@ class Points(Layer):
                 self._size = np.mean(size, axis=1)
                 warnings.warn(
                     trans._(
-                        "Point sizes must be isotropic; the average from each dimension will be used instead. "
-                        "This will become an error in a future version.",
+                        "Since 0.4.18 point sizes must be isotropic; the average from each dimension will be"
+                        " used instead. This will become an error in version 0.6.0.",
                         deferred=True,
                     ),
                     category=DeprecationWarning,
@@ -856,8 +856,8 @@ class Points(Layer):
         if isinstance(size, (list, tuple, np.ndarray)):
             warnings.warn(
                 trans._(
-                    "Point sizes must be isotropic; the average from each dimension will be used instead. "
-                    "This will become an error in a future version.",
+                    "Since 0.4.18 point sizes must be isotropic; the average from each dimension will be used instead. "
+                    "This will become an error in version 0.6.0.",
                     deferred=True,
                 ),
                 category=DeprecationWarning,


### PR DESCRIPTION
# Description

This makes `refresh` trigger async slicing by default when its corresponding experimental flag is on. As `Layer._slice_dims` is always on the sync path, that explicitly forces the refresh to be synchronous.

In most usage of napari this should be enough to avoid [#5591](https://github.com/napari/napari/issues/5591) because if the experimental flag is on and the layer supports async, then all slicing should occur on the slicing thread. If the flag is off or the layer does not support async, then all slicing occurs on the main thread.

However, a user could call `Layer.refresh(force_sync=True)` while async slicing is occurring, in which case something like https://github.com/napari/napari/pull/5610 is needed. Or they could flip the experimental flag while async slicing is occurring, with a potentially similar effect.

# References

Related to [#5591](https://github.com/napari/napari/issues/5591) but does not close it.