### PR TITLE
unchecked QtAxisListModel items nondragable

### DIFF
--- a/napari/_qt/containers/qt_axis_model.py
+++ b/napari/_qt/containers/qt_axis_model.py
@@ -16,16 +16,6 @@ class AxisModel:
         self.dims = dims
         self.axis = axis
 
-    @property
-    def rollable(self) -> bool:
-        return self.dims.rollable[self.axis]
-
-    @rollable.setter
-    def rollable(self, value: bool) -> None:
-        rollable = list(self.dims.rollable)
-        rollable[self.axis] = value
-        self.dims.rollable = rollable
-
     def __hash__(self) -> int:
         return id(self)
 
@@ -39,6 +29,16 @@ class AxisModel:
         if isinstance(other, int):
             return self.axis == other
         return repr(self) == other
+
+    @property
+    def rollable(self) -> bool:
+        return self.dims.rollable[self.axis]
+
+    @rollable.setter
+    def rollable(self, value: bool) -> None:
+        rollable = list(self.dims.rollable)
+        rollable[self.axis] = value
+        self.dims.rollable = rollable
 
 
 class AxisList(SelectableEventedList[AxisModel]):
@@ -110,5 +110,6 @@ class QtAxisListModel(QtListModel[AxisModel]):
                 return Qt.ItemFlag.ItemIsDropEnabled
             
             if self.getItem(index).rollable:
+                # we only allow dragging if the item is rollable
                 return flags | Qt.ItemFlag.ItemIsDragEnabled
             return flags & ~Qt.ItemFlag.ItemIsDragEnabled

--- a/napari/_qt/containers/qt_axis_model.py
+++ b/napari/_qt/containers/qt_axis_model.py
@@ -16,12 +16,14 @@ class AxisModel:
         self.dims = dims
         self.axis = axis
 
+    @property
     def rollable(self) -> bool:
         return self.dims.rollable[self.axis]
 
-    def set_rollable(self, r: bool) -> None:
+    @rollable.setter
+    def rollable(self, value: bool) -> None:
         rollable = list(self.dims.rollable)
-        rollable[self.axis] = r
+        rollable[self.axis] = value
         self.dims.rollable = rollable
 
     def __hash__(self) -> int:
@@ -60,7 +62,7 @@ class QtAxisListModel(QtListModel[AxisModel]):
         if role == Qt.ItemDataRole.CheckStateRole:
             return (
                 Qt.CheckState.Checked
-                if axis.rollable()
+                if axis.rollable
                 else Qt.CheckState.Unchecked
             )
         return super().data(index, role)
@@ -73,7 +75,11 @@ class QtAxisListModel(QtListModel[AxisModel]):
     ) -> bool:
         axis = self.getItem(index)
         if role == Qt.ItemDataRole.CheckStateRole:
-            axis.set_rollable(Qt.CheckState(value) == Qt.CheckState.Checked)
+            axis.rollable = Qt.CheckState(value) == Qt.CheckState.Checked
+        elif role == Qt.ItemDataRole.EditRole:
+            axis_labels = list(axis.dims.axis_labels)
+            axis_labels[axis.axis] = value
+            axis.dims.axis_labels = axis_labels
         else:
             return super().setData(index, value, role=role)
         self.dataChanged.emit(index, index, [role])
@@ -103,6 +109,6 @@ class QtAxisListModel(QtListModel[AxisModel]):
                 # we allow drops outside the items
                 return Qt.ItemFlag.ItemIsDropEnabled
             
-            if self.getItem(index).rollable():
+            if self.getItem(index).rollable:
                 return flags | Qt.ItemFlag.ItemIsDragEnabled
             return flags & ~Qt.ItemFlag.ItemIsDragEnabled

--- a/napari/_qt/widgets/qt_dims_sorter.py
+++ b/napari/_qt/widgets/qt_dims_sorter.py
@@ -67,7 +67,7 @@ class QtDimsSorter(QWidget):
 
         widget_tooltip = QtToolTipLabel(self)
         widget_tooltip.setObjectName('help_label')
-        widget_tooltip.setToolTip(trans._('Drag dimensions to reorder.'))
+        widget_tooltip.setToolTip(trans._('Drag dimensions to reorder, uncheck to lock dimension in place.'))
 
         widget_title = QLabel(trans._('Dims. Ordering'), self)
 

--- a/napari/_qt/widgets/qt_dims_sorter.py
+++ b/napari/_qt/widgets/qt_dims_sorter.py
@@ -46,21 +46,13 @@ class QtDimsSorter(QWidget):
     Modified from:
     https://github.com/jni/zarpaint/blob/main/zarpaint/_dims_chooser.py
     """
-
     def __init__(self, viewer: 'Viewer', parent=None) -> None:
         super().__init__(parent=parent)
         dims = viewer.dims
-        root = AxisList.from_dims(dims)
-        root.events.reordered.connect(
-            lambda event: set_dims_order(dims, event.value)
-        )
-        dims.events.order.connect(
-            lambda event: move_indices(root, event.value)
-        )
-        view = QtListView(root)
-        view.setSizeAdjustPolicy(QtListView.AdjustToContents)
+        self.axis_list = AxisList.from_dims(dims)
 
-        self.axes_list = root
+        view = QtListView(self.axis_list)
+        view.setSizeAdjustPolicy(QtListView.AdjustToContents)
 
         layout = QGridLayout()
         self.setLayout(layout)
@@ -74,3 +66,13 @@ class QtDimsSorter(QWidget):
         self.layout().addWidget(widget_title, 0, 0)
         self.layout().addWidget(widget_tooltip, 0, 1)
         self.layout().addWidget(view, 1, 0)
+
+        # connect axes_list and dims
+        self.axis_list.events.reordered.connect(
+            lambda event: set_dims_order(dims, event.value), 
+            until=self.parent().finished
+        )
+        dims.events.order.connect(
+            lambda event: move_indices(self.axis_list, event.value), 
+            until=self.parent().finished
+        )

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -204,16 +204,19 @@ class QtViewerButtons(QFrame):
         if self.viewer.dims.ndisplay != 2:
             return
 
-        dim_sorter = QtDimsSorter(self.viewer, self)
+        # popup
+        pop = QtPopup(self)
+        
+        # dims sorter widget
+        dim_sorter = QtDimsSorter(self.viewer, pop)
         dim_sorter.setObjectName('dim_sorter')
 
         # make layout
         layout = QHBoxLayout()
         layout.addWidget(dim_sorter)
-
-        # popup and show
-        pop = QtPopup(self)
         pop.frame.setLayout(layout)
+
+        # show popup
         pop.show_above_mouse()
 
     def _open_grid_popup(self):

--- a/napari/components/dims.py
+++ b/napari/components/dims.py
@@ -86,6 +86,8 @@ class Dims(EventedModel):
     displayed_order : tuple of int
         Order of only displayed dimensions. These are calculated from the
         ``displayed`` dimensions.
+    rollable :  tuple of int
+        Tuple of axis roll state. If True the axis is rollable.
     """
 
     # fields
@@ -220,6 +222,7 @@ class Dims(EventedModel):
         elif labels_ndim > ndim:
             updated['axis_labels'] = axis_labels[-ndim:]
 
+        # Check the rollable axes tuple has same number of elements as ndim
         rollable = values['rollable']
         n_rollable = len(rollable)
         if n_rollable < ndim:


### PR DESCRIPTION
# Fixes/Closes

<!-- In general, PRs should fix an existing issue on the repo. -->
<!-- Please link to that issue here as "Closes #(issue-number)". -->
Closes #

# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (changes required to run napari, tests, & CI smoothly)
- [ ] Enhancement (non-breaking improvements of an existing feature)
- [ ] Documentation (update of docstrings and deprecation information)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
