### PR TITLE
[WIP] deprecate properties in vectors layer

### DIFF
--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -496,7 +496,7 @@ def test_edge_color_colormap():
 
 def test_edge_color_map_non_numeric_property():
     """Test setting edge_color as a color map of a
-    non-numeric property raises an error
+    non-numeric features raises an error
     """
     np.random.seed(0)
     shape = (10, 2, 2)
@@ -530,7 +530,7 @@ def test_switching_edge_color_mode():
     shape = (10, 2, 2)
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
-    properties = {
+    features = {
         'magnitude': np.arange(shape[0]),
         'vector_type': np.array(['A', 'B'] * int(shape[0] / 2)),
     }
@@ -538,7 +538,7 @@ def test_switching_edge_color_mode():
     initial_color = [0, 1, 0, 1]
     layer = Vectors(
         data,
-        properties=properties,
+        features=features,
         edge_color=initial_color,
         edge_color_cycle=color_cycle,
         edge_colormap='gray',
@@ -557,7 +557,7 @@ def test_switching_edge_color_mode():
     # the first property in Vectors.properties is being automatically selected
     with pytest.warns(RuntimeWarning):
         layer.edge_color_mode = 'colormap'
-    assert layer._edge.color_properties.name == next(iter(properties))
+    assert layer._edge.color_properties.name == next(iter(features))
     np.testing.assert_allclose(layer.edge_color[-1], [1, 1, 1, 1])
 
     # switch to color cycle
@@ -572,16 +572,16 @@ def test_switching_edge_color_mode():
     np.testing.assert_allclose(layer.edge_color, edge_colors)
 
 
-def test_properties_color_mode_without_properties():
+def test_properties_color_mode_without_features():
     """Test that switching to a colormode requiring
-    properties without properties defined raises an exceptions
+    features without features defined raises an exceptions
     """
     np.random.seed(0)
     shape = (10, 2, 2)
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
     layer = Vectors(data)
-    assert layer.properties == {}
+    assert layer.features.empty
 
     with pytest.raises(ValueError):
         layer.edge_color_mode = 'colormap'

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -270,7 +270,6 @@ def test_features_dataframe():
 
 def test_adding_properties():
     """test adding properties to a Vectors layer"""
-    shape = (10, 2)
     np.random.seed(0)
     shape = (10, 2, 2)
     data = np.random.random(shape)
@@ -446,33 +445,32 @@ def test_edge_color_cycle():
     shape = (10, 2, 2)
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
-    properties = {'vector_type': np.array(['A', 'B'] * int(shape[0] / 2))}
+    features = {'vector_type': np.array(['A', 'B'] * int(shape[0] / 2))}
     color_cycle = ['red', 'blue']
     layer = Vectors(
         data,
-        properties=properties,
+        features=features,
         edge_color='vector_type',
         edge_color_cycle=color_cycle,
     )
-    np.testing.assert_equal(layer.properties, properties)
+    pd.testing.assert_frame_equal(layer.features, pd.DataFrame(features))
     edge_color_array = transform_color(color_cycle * int(shape[0] / 2))
     assert np.all(layer.edge_color == edge_color_array)
 
 
 def test_edge_color_colormap():
     """Test creating Vectors where edge color is set by a colormap"""
-    shape = (10, 2)
     shape = (10, 2, 2)
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
-    properties = {'angle': np.array([0, 1.5] * int(shape[0] / 2))}
+    features = {'angle': np.array([0, 1.5] * int(shape[0] / 2))}
     layer = Vectors(
         data,
-        properties=properties,
+        features=features,
         edge_color='angle',
         edge_colormap='gray',
     )
-    np.testing.assert_equal(layer.properties, properties)
+    pd.testing.assert_frame_equal(layer.features, pd.DataFrame(features))
     assert layer.edge_color_mode == 'colormap'
     edge_color_array = transform_color(['black', 'white'] * int(shape[0] / 2))
     assert np.all(layer.edge_color == edge_color_array)
@@ -504,12 +502,12 @@ def test_edge_color_map_non_numeric_property():
     shape = (10, 2, 2)
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
-    properties = {'vector_type': np.array(['A', 'B'] * int(shape[0] / 2))}
+    features = {'vector_type': np.array(['A', 'B'] * int(shape[0] / 2))}
     color_cycle = ['red', 'blue']
     initial_color = [0, 1, 0, 1]
     layer = Vectors(
         data,
-        properties=properties,
+        features=features,
         edge_color=initial_color,
         edge_color_cycle=color_cycle,
         edge_colormap='gray',

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -93,13 +93,17 @@ def test_empty_vectors_with_property_choices():
     """Test instantiating Vectors layer with empty coordinate-like 2D data."""
     shape = (0, 2, 2)
     data = np.empty(shape)
-    property_choices = {'angle': np.array([0.5], dtype=float)}
-    layer = Vectors(data, property_choices=property_choices)
+    feature_choices = {'angle': np.array([0.5], dtype=float)}
+    layer = Vectors(
+        data, features={'angle': []}, feature_defaults=feature_choices
+    )
     assert np.all(layer.data == data)
     assert layer.data.shape == shape
     assert layer.ndim == shape[2]
     assert layer._view_data.shape[2] == 2
-    np.testing.assert_equal(layer.property_choices, property_choices)
+    np.testing.assert_equal(
+        layer.feature_defaults["angle"], feature_choices["angle"]
+    )
 
 
 def test_empty_layer_with_edge_colormap():

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -278,23 +278,25 @@ def test_adding_properties():
     layer = Vectors(data)
 
     # properties should start empty
-    assert layer.properties == {}
+    with pytest.warns(DeprecationWarning):
+        assert layer.properties == {}
 
     # add properties
-    layer.properties = properties
-    np.testing.assert_equal(layer.properties, properties)
+    with pytest.warns(DeprecationWarning):
+        layer.properties = properties
+        np.testing.assert_equal(layer.properties, properties)
 
     # removing a property that was the _edge_color_property should give a warning
     layer.edge_color = 'vector_type'
     properties_2 = {
         'not_vector_type': np.array(['A', 'B'] * int(shape[0] / 2))
     }
-    with pytest.warns(RuntimeWarning):
+    with pytest.warns(DeprecationWarning):
         layer.properties = properties_2
 
     # adding properties with the wrong length should raise an exception
     bad_properties = {'vector_type': np.array(['A', 'B'])}
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
         layer.properties = bad_properties
 
 
@@ -716,5 +718,9 @@ def test_out_of_slice_display():
 def test_empty_data_from_tuple():
     """Test that empty data raises an error."""
     layer = Vectors(name="vector", ndim=3)
-    layer2 = Vectors.create(*layer.as_layer_data_tuple())
+    data, attributes, layer_type = layer.as_layer_data_tuple()
+    # properties is deprecated
+    attributes.pop('properties')
+    attributes.pop('property_choices')
+    layer2 = Vectors.create(data, attributes, layer_type)
     assert layer2.data.size == 0

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -89,7 +89,7 @@ def test_empty_vectors_with_features():
     assert_colors_equal(vectors.edge_color, list('rgb'))
 
 
-def test_empty_vectors_with_property_choices():
+def test_empty_vectors_with_features_defaults():
     """Test instantiating Vectors layer with empty coordinate-like 2D data."""
     shape = (0, 2, 2)
     data = np.empty(shape)
@@ -193,16 +193,16 @@ def test_data_setter():
     np.random.seed(0)
     data = np.random.random(shape)
     data[:, 0, :] = 20 * data[:, 0, :]
-    properties = {
+    features = {
         'prop_0': np.random.random((n_vectors_0,)),
         'prop_1': np.random.random((n_vectors_0,)),
     }
-    layer = Vectors(data, properties=properties)
+    layer = Vectors(data, features=features)
 
     assert len(layer.data) == n_vectors_0
     assert len(layer.edge_color) == n_vectors_0
-    assert len(layer.properties['prop_0']) == n_vectors_0
-    assert len(layer.properties['prop_1']) == n_vectors_0
+    assert len(layer.features['prop_0']) == n_vectors_0
+    assert len(layer.features['prop_1']) == n_vectors_0
 
     # set the data with more vectors
     n_vectors_1 = 20
@@ -212,8 +212,8 @@ def test_data_setter():
 
     assert len(layer.data) == n_vectors_1
     assert len(layer.edge_color) == n_vectors_1
-    assert len(layer.properties['prop_0']) == n_vectors_1
-    assert len(layer.properties['prop_1']) == n_vectors_1
+    assert len(layer.features['prop_0']) == n_vectors_1
+    assert len(layer.features['prop_1']) == n_vectors_1
 
     # set the data with fewer vectors
     n_vectors_2 = 5
@@ -223,8 +223,8 @@ def test_data_setter():
 
     assert len(layer.data) == n_vectors_2
     assert len(layer.edge_color) == n_vectors_2
-    assert len(layer.properties['prop_0']) == n_vectors_2
-    assert len(layer.properties['prop_1']) == n_vectors_2
+    assert len(layer.features['prop_0']) == n_vectors_2
+    assert len(layer.features['prop_1']) == n_vectors_2
 
 
 def test_properties_dataframe():
@@ -237,14 +237,35 @@ def test_properties_dataframe():
     properties = {'vector_type': np.array(['A', 'B'] * int(shape[0] / 2))}
     properties_df = pd.DataFrame(properties)
     properties_df = properties_df.astype(properties['vector_type'].dtype)
-    layer = Vectors(data, properties=properties_df)
-    np.testing.assert_equal(layer.properties, properties)
+    with pytest.warns(DeprecationWarning):
+        layer = Vectors(data, properties=properties_df)
+        np.testing.assert_equal(layer.properties, properties)
 
     # test adding a dataframe via the properties setter
     properties_2 = {'vector_type2': np.array(['A', 'B'] * int(shape[0] / 2))}
     properties_df2 = pd.DataFrame(properties_2)
-    layer.properties = properties_df2
-    np.testing.assert_equal(layer.properties, properties_2)
+    with pytest.warns(DeprecationWarning):
+        layer.properties = properties_df2
+        np.testing.assert_equal(layer.properties, properties_2)
+
+
+def test_features_dataframe():
+    """test if properties can be provided as a DataFrame"""
+    np.random.seed(0)
+    shape = (10, 2, 2)
+    data = np.random.random(shape)
+    data[:, 0, :] = 20 * data[:, 0, :]
+    properties = {'vector_type': np.array(['A', 'B'] * int(shape[0] / 2))}
+    features_df = pd.DataFrame(properties)
+    features_df = features_df.astype(properties['vector_type'].dtype)
+    layer = Vectors(data, features=features_df)
+    pd.testing.assert_frame_equal(layer.features, features_df)
+
+    # test adding a dataframe via the properties setter
+    features_2 = {'vector_type2': np.array(['A', 'B'] * int(shape[0] / 2))}
+    features_df2 = pd.DataFrame(features_2)
+    layer.features = features_df2
+    pd.testing.assert_frame_equal(layer.features, features_df2)
 
 
 def test_adding_properties():

--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -110,10 +110,11 @@ def test_empty_layer_with_edge_colormap():
     """Test creating an empty layer where the edge color is a colormap"""
     shape = (0, 2, 2)
     data = np.empty(shape)
-    default_properties = {'angle': np.array([1.5], dtype=float)}
+    default_features = {'angle': np.array([1.5], dtype=float)}
     layer = Vectors(
         data=data,
-        property_choices=default_properties,
+        features={'angle': []},
+        feature_defaults=default_features,
         edge_color='angle',
         edge_colormap='grays',
     )
@@ -129,10 +130,11 @@ def test_empty_layer_with_edge_color_cycle():
     """Test creating an empty layer where the edge color is a color cycle"""
     shape = (0, 2, 2)
     data = np.empty(shape)
-    default_properties = {'vector_type': np.array(['A'])}
+    default_features = {'vector_type': np.array(['A'])}
     layer = Vectors(
         data=data,
-        property_choices=default_properties,
+        features={'vector_type': np.empty((0,), dtype=str)},
+        feature_defaults=default_features,
         edge_color='vector_type',
     )
 

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -9,12 +9,18 @@ from napari.layers.base import Layer
 from napari.layers.utils._color_manager_constants import ColorMode
 from napari.layers.utils.color_manager import ColorManager
 from napari.layers.utils.color_transformations import ColorType
-from napari.layers.utils.layer_utils import _FeatureTable
+from napari.layers.utils.layer_utils import (
+    _FeatureTable,
+    _properties_deprecation_message,
+    _property_choices_deprecation_message,
+    _warn_deprecation,
+)
 from napari.layers.vectors._vector_utils import fix_data_vectors
 from napari.layers.vectors._vectors_constants import VectorStyle
 from napari.utils.colormaps import Colormap, ValidColormapArg
 from napari.utils.events import Event
 from napari.utils.events.custom_types import Array
+from napari.utils.events.event import WarningEmitter
 from napari.utils.translations import trans
 
 
@@ -221,7 +227,10 @@ class Vectors(Layer):
             edge_color=Event,
             vector_style=Event,
             edge_color_mode=Event,
-            properties=Event,
+            properties=WarningEmitter(
+                _properties_deprecation_message(),
+                type_name='properties',
+            ),
             out_of_slice_display=Event,
             features=Event,
             feature_defaults=Event,
@@ -236,6 +245,10 @@ class Vectors(Layer):
 
         self._data = data
 
+        if properties is not None:
+            _warn_deprecation(_properties_deprecation_message())
+        if property_choices is not None:
+            _warn_deprecation(_property_choices_deprecation_message())
         self._feature_table = _FeatureTable.from_layer(
             features=features,
             feature_defaults=feature_defaults,
@@ -250,7 +263,7 @@ class Vectors(Layer):
             continuous_colormap=edge_colormap,
             contrast_limits=edge_contrast_limits,
             categorical_colormap=edge_color_cycle,
-            properties=self.properties
+            properties=self._feature_table.properties()
             if self._data.size > 0
             else self._feature_table.currents(),
         )
@@ -349,10 +362,12 @@ class Vectors(Layer):
     @property
     def properties(self) -> Dict[str, np.ndarray]:
         """dict {str: array (N,)}, DataFrame: Annotations for each point"""
+        _warn_deprecation(_properties_deprecation_message())
         return self._feature_table.properties()
 
     @properties.setter
     def properties(self, properties: Dict[str, Array]):
+        _warn_deprecation(_properties_deprecation_message())
         self.features = properties
 
     @property
@@ -372,6 +387,7 @@ class Vectors(Layer):
 
     @property
     def property_choices(self) -> Dict[str, np.ndarray]:
+        _warn_deprecation(_property_choices_deprecation_message())
         return self._feature_table.choices()
 
     def _get_state(self):
@@ -395,14 +411,18 @@ class Vectors(Layer):
                 'edge_colormap': self.edge_colormap.name,
                 'edge_contrast_limits': self.edge_contrast_limits,
                 'data': self.data,
-                'properties': self.properties,
-                'property_choices': self.property_choices,
+                'properties': self._feature_table.properties(),
+                'property_choices': self._feature_table.choices(),
                 'ndim': self.ndim,
                 'features': self.features,
                 'feature_defaults': self.feature_defaults,
                 'out_of_slice_display': self.out_of_slice_display,
             }
         )
+        state.deprecations = {
+            'properties': _properties_deprecation_message(),
+            'property_choices': _property_choices_deprecation_message(),
+        }
         return state
 
     def _get_ndim(self) -> int:
@@ -494,7 +514,7 @@ class Vectors(Layer):
         self._edge._set_color(
             color=edge_color,
             n_colors=len(self.data),
-            properties=self.properties,
+            properties=self._feature_table.properties(),
             current_properties=self._feature_table.currents(),
         )
         self.events.edge_color()
@@ -513,7 +533,9 @@ class Vectors(Layer):
             the color cycle map or colormap), set update_color_mapping=False.
             Default value is False.
         """
-        self._edge._refresh_colors(self.properties, update_color_mapping)
+        self._edge._refresh_colors(
+            self._feature_table.properties(), update_color_mapping
+        )
 
     @property
     def edge_color_mode(self) -> ColorMode:
@@ -539,14 +561,14 @@ class Vectors(Layer):
             else:
                 color_property = ''
             if color_property == '':
-                if self.properties:
-                    color_property = next(iter(self.properties))
+                if self.features.shape[1] > 0:
+                    new_color_property = next(iter(self.features))
                     self._edge.color_properties = {
                         'name': color_property,
-                        'values': self.features[color_property].to_numpy(),
-                        'current_value': self.feature_defaults[color_property][
-                            0
-                        ],
+                        'values': self.features[new_color_property].to_numpy(),
+                        'current_value': self.feature_defaults[
+                            new_color_property
+                        ][0],
                     }
                     warnings.warn(
                         trans._(
@@ -567,7 +589,7 @@ class Vectors(Layer):
 
             # ColorMode.COLORMAP can only be applied to numeric properties
             if (edge_color_mode == ColorMode.COLORMAP) and not issubclass(
-                self.properties[color_property].dtype.type,
+                self.features[color_property].dtype.type,
                 np.number,
             ):
                 raise TypeError(

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -562,13 +562,13 @@ class Vectors(Layer):
                 color_property = ''
             if color_property == '':
                 if self.features.shape[1] > 0:
-                    new_color_property = next(iter(self.features))
+                    color_property = next(iter(self.features))
                     self._edge.color_properties = {
                         'name': color_property,
-                        'values': self.features[new_color_property].to_numpy(),
-                        'current_value': self.feature_defaults[
-                            new_color_property
-                        ][0],
+                        'values': self.features[color_property].to_numpy(),
+                        'current_value': self.feature_defaults[color_property][
+                            0
+                        ],
                     }
                     warnings.warn(
                         trans._(


### PR DESCRIPTION
# Description
This PR deprecates properties in the vectors layer based on the approach in https://github.com/napari/napari/pull/5477

# References
Should be merged into https://github.com/napari/napari/pull/5477

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (changes required to run napari, tests, & CI smoothly)
- [ ] Enhancement (non-breaking improvements of an existing feature)
- [ ] Documentation (update of docstrings and deprecation information)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
