### PR TITLE
Deprecated properies that handles also Image class

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -60,6 +60,7 @@ from napari.utils.geometry import (
     intersect_line_with_axis_aligned_bounding_box_3d,
 )
 from napari.utils.key_bindings import KeymapProvider
+from napari.utils.migrations import DeprecatingDict
 from napari.utils.misc import StringEnum
 from napari.utils.mouse_bindings import MousemapProvider
 from napari.utils.naming import magic_name
@@ -1023,6 +1024,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     def as_layer_data_tuple(self):
         state = self._get_state()
         state.pop('data', None)
+        if hasattr(self.__init__, '_rename_argument'):
+            state = DeprecatingDict(state)
+            for element in self.__init__._rename_argument:
+                state.deprecate(element)
         return self.data, state, self._type_string
 
     @property

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -60,7 +60,6 @@ from napari.utils.events.migrations import deprecation_warning_event
 from napari.utils.geometry import project_points_onto_plane, rotate_points
 from napari.utils.migrations import (
     DeprecatedProperty,
-    DeprecatingDict,
     add_deprecated_property,
     rename_argument,
 )
@@ -1499,10 +1498,6 @@ class Points(Layer):
                 'shown': self.shown,
             }
         )
-        state = DeprecatingDict(state)
-        for prop in self._deprecated_properties:
-            if prop.new_name in state:
-                state.deprecate(prop)
         return state
 
     @property

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -62,7 +62,7 @@ def rename_argument(
             func._rename_argument = []
 
         func._rename_argument.append(
-            (from_name, to_name, version, since_version)
+            DeprecatedProperty(from_name, to_name, version, since_version)
         )
 
         @wraps(func)


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/6976

# Description

I just realized that state is a set of arguments to the constructor, so we should not depend on `add_deprecated_property` but on the results of `rename_argument` 

The `rename_argument` already defines `class.__init_._rename_argument` attribute that is used for generation of `add_xxx` methods. 

This approach of changes also handle renaming of `interpolation` to `interpolation2d` in the `Image` class.

As an improvement, PR may contain an update of `rename_argument` to use `DeprecatedProperty.message` in `warnings.warn` used in `rename_argument` 